### PR TITLE
Add one-command Antigravity installer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,23 @@ jobs:
     - name: Run test suite
       run: |
         python fable_engine/test_server.py
+
+    - name: Validate PowerShell installers
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $parseErrors = @()
+        foreach ($path in @('install.ps1', 'install-antigravity.ps1')) {
+          $tokens = $null
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Join-Path $PWD $path), [ref]$tokens, [ref]$errors
+          ) | Out-Null
+          $parseErrors += $errors
+        }
+        if ($parseErrors.Count -gt 0) {
+          $parseErrors | Format-List *
+          exit 1
+        }
+        Write-Host 'PowerShell installer syntax is valid.'
+

--- a/README.md
+++ b/README.md
@@ -320,10 +320,10 @@ stateDiagram-v2
 **Fastest path — no Git required:** open PowerShell and run this single line:
 
 ```powershell
-$installer="$env:TEMP\fable-mode-install.ps1"; Invoke-WebRequest -Uri "https://raw.githubusercontent.com/REX-codebase/fable-mode/main/install-antigravity.ps1" -OutFile $installer; & $installer
+$installer="$env:TEMP\fable-mode-install.ps1"; Invoke-WebRequest -Uri "https://raw.githubusercontent.com/REX-codebase/fable-mode/458a72985e4a31e2794b2a9a0fe967abf16a421f/install-antigravity.ps1" -OutFile $installer; & $installer
 ```
 
-The bootstrap downloads the public REX-codebase package, runs the verification suite, installs the skill and MCP server, safely merges `fable-engine` into the host configuration, and keeps a backup of an existing config file. Use `-NoRegisterMcp` if you want to review the generated configuration before registering it.
+The bootstrap downloads a pinned REX-codebase package, verifies its SHA-256 digest before executing any downloaded installer code, runs the verification suite, installs the skill and MCP server, safely merges `fable-engine` into the host configuration, and keeps a backup of an existing config file. The command is pinned to a reviewed commit rather than mutable `main`; update the commit URL and installer checksum together for a new release. Use `-NoRegisterMcp` if you want to review the generated configuration before registering it.
 
 **From a local clone:**
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ stateDiagram-v2
 **Fastest path — no Git required:** open PowerShell and run this single line:
 
 ```powershell
-$installer="$env:TEMP\fable-mode-install.ps1"; Invoke-WebRequest -Uri "https://raw.githubusercontent.com/REX-codebase/fable-mode/458a72985e4a31e2794b2a9a0fe967abf16a421f/install-antigravity.ps1" -OutFile $installer; & $installer
+$installer="$env:TEMP\fable-mode-install.ps1"; Invoke-WebRequest -Uri "https://raw.githubusercontent.com/REX-codebase/fable-mode/fc771cca41f24a46a460a5bd291e125558196a8e/install-antigravity.ps1" -OutFile $installer; & $installer
 ```
 
 The bootstrap downloads a pinned REX-codebase package, verifies its SHA-256 digest before executing any downloaded installer code, runs the verification suite, installs the skill and MCP server, safely merges `fable-engine` into the host configuration, and keeps a backup of an existing config file. The command is pinned to a reviewed commit rather than mutable `main`; update the commit URL and installer checksum together for a new release. Use `-NoRegisterMcp` if you want to review the generated configuration before registering it.

--- a/README.md
+++ b/README.md
@@ -317,18 +317,23 @@ stateDiagram-v2
 
 ### Option A: Windows 1-Click Automated Installer (Recommended)
 
-Run the included PowerShell installer from the repository root:
+**Fastest path — no Git required:** open PowerShell and run this single line:
 
 ```powershell
-# Clone the repository
-git clone https://github.com/REX-codebase/fable-mode.git
-cd fable-mode
-
-# Execute 1-click installer (auto-configures MCP, skills, rules & tests)
-powershell -ExecutionPolicy Bypass -File .\install.ps1
+$installer="$env:TEMP\fable-mode-install.ps1"; Invoke-WebRequest -Uri "https://raw.githubusercontent.com/REX-codebase/fable-mode/main/install-antigravity.ps1" -OutFile $installer; & $installer
 ```
 
-The installer verifies your Python runtime, registers the `fable-engine` MCP server, deploys all cognitive skills and rule directives, and executes the 13 automated invariant test suites.
+The bootstrap downloads the public REX-codebase package, runs the verification suite, installs the skill and MCP server, safely merges `fable-engine` into the host configuration, and keeps a backup of an existing config file. Use `-NoRegisterMcp` if you want to review the generated configuration before registering it.
+
+**From a local clone:**
+
+```powershell
+git clone https://github.com/REX-codebase/fable-mode.git
+cd fable-mode
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -RegisterMcp
+```
+
+The installer verifies your Python runtime, registers the `fable-engine` MCP server, deploys all cognitive skills and rule directives, and runs the complete verification suite.
 
 ---
 

--- a/install-antigravity.ps1
+++ b/install-antigravity.ps1
@@ -17,7 +17,11 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$repoArchive = "https://api.github.com/repos/REX-codebase/fable-mode/zipball/main"
+# Pin the downloaded source to an immutable commit and verify the archive bytes
+# before any installer code is executed. Update both values together for a release.
+$pinnedCommit = "458a72985e4a31e2794b2a9a0fe967abf16a421f"
+$expectedArchiveSha256 = "92ed89abdc8a66738418ce0f6f74a8a50968e304247afd53ef29a0e9cdf0b0f9"
+$repoArchive = "https://api.github.com/repos/REX-codebase/fable-mode/zipball/$pinnedCommit"
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("fable-mode-" + [guid]::NewGuid().ToString("N"))
 $archivePath = Join-Path $tempRoot "fable-mode.zip"
 
@@ -28,6 +32,11 @@ try {
         Accept = "application/vnd.github+json"
         "User-Agent" = "fable-mode-installer"
     }
+    $actualArchiveSha256 = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualArchiveSha256 -ne $expectedArchiveSha256) {
+        throw "Downloaded archive integrity check failed; no installer code was executed."
+    }
+    Write-Host "[OK] Verified commit $pinnedCommit and SHA-256 $actualArchiveSha256" -ForegroundColor Green
 
     Write-Host "[+] Expanding package..." -ForegroundColor Cyan
     Expand-Archive -Path $archivePath -DestinationPath $tempRoot -Force

--- a/install-antigravity.ps1
+++ b/install-antigravity.ps1
@@ -17,10 +17,11 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-# Pin the downloaded source to an immutable commit and verify the archive bytes
-# before any installer code is executed. Update both values together for a release.
-$pinnedCommit = "458a72985e4a31e2794b2a9a0fe967abf16a421f"
-$expectedArchiveSha256 = "92ed89abdc8a66738418ce0f6f74a8a50968e304247afd53ef29a0e9cdf0b0f9"
+# Pin the downloaded source to an immutable reviewed commit and verify the
+# archive bytes before any installer code is executed. Update both values
+# together for a release. The bootstrap itself is pinned separately in README.
+$pinnedCommit = "2c049cb77a5ba5066d7bcbcf2f488c272b6c0195"
+$expectedArchiveSha256 = "8d470ba5854c55cd6b23736e1fb28dfff8a9e8e703db25b2030e197a7b9ad85c"
 $repoArchive = "https://api.github.com/repos/REX-codebase/fable-mode/zipball/$pinnedCommit"
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("fable-mode-" + [guid]::NewGuid().ToString("N"))
 $archivePath = Join-Path $tempRoot "fable-mode.zip"

--- a/install-antigravity.ps1
+++ b/install-antigravity.ps1
@@ -1,0 +1,59 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    One-command installer for Fable-Mode in an Antigravity-compatible host layout.
+.DESCRIPTION
+    Downloads the public REX-codebase repository archive, expands it in a
+    temporary directory, runs the verified local installer, and optionally merges
+    the fable-engine entry into the host MCP configuration without overwriting
+    other servers.
+#>
+[CmdletBinding()]
+param(
+    [string]$TargetDir = "$HOME\.gemini",
+    [switch]$SkipTests,
+    [switch]$NoRegisterMcp,
+    [switch]$KeepDownload
+)
+
+$ErrorActionPreference = "Stop"
+$repoArchive = "https://api.github.com/repos/REX-codebase/fable-mode/zipball/main"
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("fable-mode-" + [guid]::NewGuid().ToString("N"))
+$archivePath = Join-Path $tempRoot "fable-mode.zip"
+
+try {
+    New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+    Write-Host "[+] Downloading Fable-Mode from REX-codebase..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $repoArchive -OutFile $archivePath -Headers @{
+        Accept = "application/vnd.github+json"
+        "User-Agent" = "fable-mode-installer"
+    }
+
+    Write-Host "[+] Expanding package..." -ForegroundColor Cyan
+    Expand-Archive -Path $archivePath -DestinationPath $tempRoot -Force
+    $sourceRoot = Get-ChildItem -Path $tempRoot -Directory |
+        Where-Object { $_.FullName -ne $tempRoot } |
+        Select-Object -First 1
+    if (-not $sourceRoot -or -not (Test-Path (Join-Path $sourceRoot.FullName "install.ps1"))) {
+        throw "Downloaded archive did not contain a valid Fable-Mode installer."
+    }
+
+    $installer = Join-Path $sourceRoot.FullName "install.ps1"
+    $registerMcp = -not $NoRegisterMcp
+    Write-Host "[+] Installing into the host-compatible layout..." -ForegroundColor Cyan
+    & $installer `
+        -TargetDir $TargetDir `
+        -SkipTests:$SkipTests `
+        -RegisterMcp:$registerMcp
+
+    Write-Host "`n[OK] Fable-Mode is installed and ready." -ForegroundColor Green
+} catch {
+    Write-Error "Fable-Mode installation failed: $($_.Exception.Message)"
+    exit 1
+} finally {
+    if (-not $KeepDownload -and (Test-Path $tempRoot)) {
+        Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    } elseif ($KeepDownload) {
+        Write-Host "[i] Download retained at: $tempRoot" -ForegroundColor Yellow
+    }
+}

--- a/install.ps1
+++ b/install.ps1
@@ -6,6 +6,7 @@
 [CmdletBinding()]
 param(
     [switch]$SkipTests = $false,
+    [switch]$RegisterMcp = $false,
     [string]$TargetDir = "$HOME\.gemini"
 )
 
@@ -85,12 +86,59 @@ if (-not $SkipTests) {
     if ($LASTEXITCODE -eq 0) {
         Write-Success "Fable-Engine verification suite PASSED."
     } else {
-        Write-Alert "Tests finished with warnings or issues. Output log:"
         Write-Host $testOutput -ForegroundColor Red
+        throw "Fable-Engine verification failed; installation aborted."
     }
 }
 
-# Step 6: Final Setup Summary
+# Step 6: Register the server without clobbering existing MCP entries.
+if ($RegisterMcp) {
+    Write-Step "Registering fable-engine with the MCP host..."
+    $McpConfig = Join-Path $TargetDir "antigravity\mcp_config.json"
+    $McpConfigDir = Split-Path -Parent $McpConfig
+    New-Item -ItemType Directory -Path $McpConfigDir -Force | Out-Null
+    $config = [ordered]@{}
+    if (Test-Path $McpConfig) {
+        try {
+            $rawConfig = Get-Content -Raw -Path $McpConfig
+            if ($rawConfig.Trim()) {
+                $parsedConfig = $rawConfig | ConvertFrom-Json
+                foreach ($property in $parsedConfig.PSObject.Properties) {
+                    $config[$property.Name] = $property.Value
+                }
+            }
+        } catch {
+            Write-Alert "Existing MCP config is not valid JSON; leaving it untouched at $McpConfig."
+            $RegisterMcp = $false
+        }
+    }
+
+    if ($RegisterMcp) {
+        if (-not $config.Contains("mcpServers") -or $null -eq $config["mcpServers"]) {
+            $config["mcpServers"] = [pscustomobject]@{}
+        }
+        $servers = $config["mcpServers"]
+        $entry = [pscustomobject][ordered]@{
+            command = "python"
+            args = @((Join-Path $McpTarget "server.py"))
+        }
+        if ($servers.PSObject.Properties.Name -contains "fable-engine") {
+            $servers."fable-engine" = $entry
+        } else {
+            $servers | Add-Member -MemberType NoteProperty -Name "fable-engine" -Value $entry
+        }
+
+        if (Test-Path $McpConfig) {
+            Copy-Item $McpConfig "$McpConfig.bak" -Force
+        }
+        $tempConfig = "$McpConfig.tmp"
+        $config | ConvertTo-Json -Depth 20 | Set-Content -Path $tempConfig -Encoding UTF8
+        Move-Item -Path $tempConfig -Destination $McpConfig -Force
+        Write-Success "Registered fable-engine in: $McpConfig"
+    }
+}
+
+# Step 7: Final Setup Summary
 Write-Host @"
 
 ================================================================================
@@ -115,7 +163,7 @@ Write-Host @"
    }
  }
 
- Ready to deliberate! Trigger with /deepthink, /fable, or set a 45m budget.
+ Ready to deliberate! Trigger Fable-Mode in your MCP host or set an authority budget.
 ================================================================================
 "@ -ForegroundColor Green
 

--- a/install.ps1
+++ b/install.ps1
@@ -108,8 +108,7 @@ if ($RegisterMcp) {
                 }
             }
         } catch {
-            Write-Alert "Existing MCP config is not valid JSON; leaving it untouched at $McpConfig."
-            $RegisterMcp = $false
+            throw "Existing MCP config is invalid JSON; installation aborted without modifying it."
         }
     }
 
@@ -118,6 +117,9 @@ if ($RegisterMcp) {
             $config["mcpServers"] = [pscustomobject]@{}
         }
         $servers = $config["mcpServers"]
+        if ($servers -is [System.Array] -or $servers -is [string] -or $servers -is [ValueType]) {
+            throw "Existing MCP config has an invalid mcpServers value; expected a JSON object."
+        }
         $entry = [pscustomobject][ordered]@{
             command = "python"
             args = @((Join-Path $McpTarget "server.py"))


### PR DESCRIPTION
## Summary

Make installing Fable-Mode in an Antigravity-compatible host layout a genuinely low-friction experience.

### User experience

Users can now download and install without Git by running one PowerShell command:

```powershell
$installer="$env:TEMP\fable-mode-install.ps1"; Invoke-WebRequest -Uri "https://raw.githubusercontent.com/REX-codebase/fable-mode/main/install-antigravity.ps1" -OutFile $installer; & $installer
```

### What it does

- Downloads the public REX-codebase archive.
- Runs the complete verification suite before completing installation.
- Installs the cognitive skill, MCP server, and generated schema.
- Safely merges `fable-engine` into the host MCP config.
- Creates a `.bak` backup before changing an existing config.
- Supports `-NoRegisterMcp`, `-SkipTests`, and `-KeepDownload`.
- Fails closed when verification or configuration parsing fails.
- Adds Windows CI syntax validation for both PowerShell installers.
- Keeps all branding and ownership language independent of any host/vendor.

## Verification

- `python3 -m py_compile fable_engine/server.py fable_engine/test_server.py`
- `python3 fable_engine/test_server.py` — 16 tests passing
- PowerShell installer syntax validation added to the Windows CI matrix.

## Security/reliability hardening

- Pin the bootstrap archive to reviewed commit `2c049cb77a5ba5066d7bcbcf2f488c272b6c0195`.
- Verify the downloaded archive SHA-256 before extracting or executing installer code.
- Pin the documented one-liner to the immutable installer commit rather than mutable `main`.
- Abort registration on invalid JSON instead of reporting a false success.
- Reject valid-but-malformed `mcpServers` arrays/scalars and require a JSON object.


## Entrypoint pinning follow-up

- The documented raw installer entrypoint is now pinned to the hardened bootstrap commit `fc771cca41f24a46a460a5bd291e125558196a8e`.
- That bootstrap verifies the reviewed package commit `2c049cb77a5ba5066d7bcbcf2f488c272b6c0195` with SHA-256 `8d470ba5854c55cd6b23736e1fb28dfff8a9e8e703db25b2030e197a7b9ad85c`.
- This two-level pin prevents the advertised one-liner from silently retrieving an older or mutable bootstrap.
