### PR TITLE
feat: add portable Fable V2 runtime foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,3 +526,21 @@ fable-mode/
 
 </div>
 
+
+
+## 🧭 Fable V2 Portable Runtime (Experimental)
+
+Fable V2 evolves the project from a cognitive prompt and session manager into
+an evidence-gated, model-agnostic runtime. Its goal is to improve weak and
+frontier models through structured task contracts, diverse candidate search,
+real tool receipts, independent verification, targeted repair, adaptive
+compute, and portable host adapters.
+
+MCP is used as a tool interface, not as the intelligence itself. The portable
+core lives in `fable_v2/`; see [`docs/fable-v2-architecture.md`](docs/fable-v2-architecture.md)
+for the architecture, enforcement model, adapter contract, and benchmark
+criteria.
+
+The 10x/50x uplift figures are ambitious hypotheses for measured task classes,
+not universal guarantees. Results must be established on held-out benchmarks
+with success, error reduction, cost, latency, and verifier-quality metrics.

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -78,20 +78,37 @@ produce a `ToolReceipt` containing:
 
 Evidence must reference a successful receipt. A candidate cannot be finalized
 until the task's declared capabilities and evidence kinds have been satisfied
-and at least one independent verifier has passed it.
+and its `VerificationPolicy` has passed.
 
-The runtime enforces required capabilities for the task, not every available
-tool. Requiring irrelevant tools would create waste and tool theatre.
+Verification is policy-enforced, not a free-form boolean. A result supplied
+from a model-facing call is rejected. A verifier must be registered by trusted
+runtime code, run against the exact candidate artifact, and be runtime-attested
+with the candidate hash. The task policy can require verifier classes such as
+`deterministic`, `machine-check`, and `independent`, a minimum number of passing
+verifiers, and at least one independently registered verifier. The runtime can
+prove that the registered checker ran on the exact artifact; semantic trust in
+a model judge remains an explicit deployment decision and should be backed by
+calibration and hidden tests.
+
+Deterministic verifiers should be executed before independent model judges by
+the host orchestrator. The core records the order and rejects missing policy
+classes, but it does not pretend that an arbitrary `VerificationResult` proves
+anything.
+
+The runtime enforces required capabilities and verifier classes for the task,
+not every available tool. Requiring irrelevant tools would create waste and
+tool theatre.
 
 ## Runtime objects
 
 The initial portable contract is implemented in `fable_v2/protocol.py`:
 
 - `TaskSpec`: task contract and definition of done;
+- `VerificationPolicy`: required verifier classes and pass thresholds;
 - `ToolReceipt`: host-produced invocation receipt;
 - `Evidence`: claim anchored to a successful receipt;
 - `Candidate`: one solution or trajectory;
-- `VerificationResult`: deterministic or independent model verdict.
+- `VerificationResult`: runtime-attested verdict bound to one candidate artifact.
 
 `fable_v2/runtime.py` implements the evidence-gated run state machine. It is
 intentionally model-agnostic and dependency-free. Hosts can wrap compilers,

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -191,6 +191,21 @@ The suite is still a runtime-foundation suite. It does not replace real host
 adapters, sandbox tests, hidden task benchmarks, or calibration of model-based
 judges.
 
+## Checkpoint trust boundary
+
+`FableRun.to_dict()` and `from_dict()` provide serialization and restoration,
+not a generally tamper-proof audit artifact. The event hash chain detects
+edited or reordered events, but the experimental checkpoint currently stores
+the HMAC attestation secret in the same payload. Someone who can rewrite that
+payload could rewrite state and recompute the in-process HMAC.
+
+Production checkpoints must keep signing keys outside the serialized state,
+ideally in an external key store or isolated broker. The broker should sign
+the canonical complete checkpoint, verify a monotonic checkpoint sequence,
+and refuse to restore trusted verification state from an unsigned or invalid
+checkpoint. The current round-trip test proves serialization correctness only;
+it is not a security test.
+
 ## Success criteria
 
 For each target domain, publish:

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -76,9 +76,13 @@ produce a `ToolReceipt` containing:
 - success/failure status;
 - timestamps and host metadata.
 
-Evidence must reference a successful receipt. A candidate cannot be finalized
-until the task's declared capabilities and evidence kinds have been satisfied
-and its `VerificationPolicy` has passed.
+Evidence must be constructed from a successful receipt using
+`Evidence.from_receipt(...)`. The receipt retains the actual tool output and
+its canonical hash; construction recomputes the content hash, and attachment
+rejects any mismatch between evidence content, evidence hash, and the receipt
+output hash. A candidate cannot be finalized until the task's declared
+capabilities and evidence kinds have been satisfied and its
+`VerificationPolicy` has passed.
 
 Verification is policy-enforced, not a free-form boolean. A result supplied
 from a model-facing call is rejected. A verifier must be registered by trusted
@@ -105,8 +109,8 @@ The initial portable contract is implemented in `fable_v2/protocol.py`:
 
 - `TaskSpec`: task contract and definition of done;
 - `VerificationPolicy`: required verifier classes and pass thresholds;
-- `ToolReceipt`: host-produced invocation receipt;
-- `Evidence`: claim anchored to a successful receipt;
+- `ToolReceipt`: host-produced invocation receipt with the actual output hash;
+- `Evidence`: claim constructed from receipt output and integrity-bound to it;
 - `Candidate`: one solution or trajectory;
 - `VerificationResult`: runtime-attested verdict bound to one candidate artifact.
 

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -105,14 +105,19 @@ capabilities and evidence kinds have been satisfied and its
 `VerificationPolicy` has passed.
 
 Verification is policy-enforced, not a free-form boolean. A result supplied
-from a model-facing call is rejected. A verifier must be registered by trusted
-runtime code, run against the exact candidate artifact, and be runtime-attested
-with the candidate hash. The task policy can require verifier classes such as
-`deterministic`, `machine-check`, and `independent`, a minimum number of passing
-verifiers, and at least one independently registered verifier. The runtime can
-prove that the registered checker ran on the exact artifact; semantic trust in
-a model judge remains an explicit deployment decision and should be backed by
-calibration and hidden tests.
+from a model-facing call is rejected. The in-process foundation API runs a
+verifier against the exact candidate artifact and runtime-attests that
+invocation with the candidate hash. This blocks forged model results, but it
+is **not** a security boundary against arbitrary Python application code: an
+in-process caller can still construct or alter verifier code. The task policy
+can require verifier classes such as `deterministic`, `machine-check`, and
+`independent`, a minimum number of passing verifiers, and a minimum trust
+boundary. The current foundation supports `in_process`; production-grade
+`process_attested` results must come from a separate broker with process
+isolation and signed/ authenticated registrations.
+
+Semantic trust in a model judge remains an explicit deployment decision and
+should be backed by calibration and hidden tests.
 
 Deterministic verifiers should be executed before independent model judges by
 the host orchestrator. The core records the order and rejects missing policy

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -1,0 +1,142 @@
+# Fable V2: Portable Verifier-Guided Runtime
+
+## Goal
+
+Build a portable, model-agnostic intelligence runtime that works across
+Antigravity, Claude Code, Codex, Grok Build, Cursor, Zapia, and other agentic
+hosts. Fable V2 should make weak-but-functional models dramatically more
+useful on verifiable task classes and make frontier models more reliable,
+consistent, and efficient.
+
+The ambitious targets are hypotheses to be measured, not guarantees:
+
+- Up to 10x improvement in system-level effectiveness for frontier models
+  (verified success, failure reduction, or successful tasks per cost).
+- Up to 50x relative improvement for weak models on selected tasks where the
+  baseline has non-zero competence.
+
+A model cannot be made universally 10x more intelligent by a prompt. Fable
+scales useful work by coordinating models, tools, evidence, search, repair,
+and verification.
+
+## Design principle
+
+> Do not ask an agent to claim that it did good work. Make the runtime collect
+> receipts, run checks, and accept only a verified artifact.
+
+MCP is a transport/interface layer. Fable V2 is the runtime around it: a
+controller, evidence ledger, model router, candidate manager, verifier broker,
+repair loop, and host adapters.
+
+## Architecture
+
+```text
+User task
+   |
+   v
+Task compiler: objective, constraints, done conditions, required capabilities
+   |
+   v
+Budget + model router ---- host capability probe
+   |
+   v
+Diverse candidate fleet ---- tools / sandbox / retrieval
+   |
+   v
+Evidence receipts and failure classification
+   |
+   v
+Deterministic verifiers -> independent model verifier -> repair/search loop
+   |
+   v
+Finalization gate: only a passing, evidence-backed artifact is accepted
+```
+
+## Portable core and adapters
+
+The core speaks a host-neutral JSON/data contract. Adapters translate native
+host tools into capabilities such as `inspect_files`, `execute_command`,
+`run_tests`, `search_web`, `edit_files`, and `delegate_agents`.
+
+Supported integrations should be implemented as thin adapters, not forks of
+the cognitive engine. MCP is the preferred tool binding, but a CLI or HTTP
+adapter is required for hosts that do not expose MCP.
+
+An adapter must probe and advertise actual capabilities at startup. A host
+must never receive a full-guarantee status merely because it loaded a prompt.
+
+## Enforcement model
+
+A model-facing prompt cannot prove that a tool was used. Each host tool must
+produce a `ToolReceipt` containing:
+
+- session and tool identity;
+- normalized capability;
+- hashes of tool input and output;
+- success/failure status;
+- timestamps and host metadata.
+
+Evidence must reference a successful receipt. A candidate cannot be finalized
+until the task's declared capabilities and evidence kinds have been satisfied
+and at least one independent verifier has passed it.
+
+The runtime enforces required capabilities for the task, not every available
+tool. Requiring irrelevant tools would create waste and tool theatre.
+
+## Runtime objects
+
+The initial portable contract is implemented in `fable_v2/protocol.py`:
+
+- `TaskSpec`: task contract and definition of done;
+- `ToolReceipt`: host-produced invocation receipt;
+- `Evidence`: claim anchored to a successful receipt;
+- `Candidate`: one solution or trajectory;
+- `VerificationResult`: deterministic or independent model verdict.
+
+`fable_v2/runtime.py` implements the evidence-gated run state machine. It is
+intentionally model-agnostic and dependency-free. Hosts can wrap compilers,
+test runners, browsers, citation checkers, symbolic tools, or model judges
+behind the same verifier contract in `fable_v2/verifiers.py`.
+
+## Quality and safety rules
+
+1. No self-attested `[PROVEN]` claims.
+2. Deterministic checks run before model judges.
+3. Generator and verifier should be independent for difficult tasks.
+4. Failed attempts are classified and reused for targeted repair.
+5. Compute is allocated adaptively; a fixed waiting timer is not computation.
+6. Finalization is rejected when receipts, evidence, or verification are missing.
+7. Execution permissions must ultimately be enforced by a sandbox/broker, not
+   only by a model-facing MCP flag.
+8. All host adapters run the same conformance tasks and report unsupported
+   capabilities honestly.
+
+## Implementation sequence
+
+1. Benchmark harness: compare model-alone, current Fable, and Fable V2 on a
+   held-out task set with success, cost, latency, and failure metrics.
+2. Task compiler and typed event log.
+3. Candidate manager with diverse/parallel trajectories.
+4. Verifier broker for tests, citations, schemas, and independent judges.
+5. Failure classification and targeted repair loop.
+6. Host adapters and capability conformance suite.
+7. Persistent experience store, model router, and optional learned verifier.
+8. Publish results only after hidden evaluation; do not claim 10x/50x from
+   plumbing tests.
+
+## Success criteria
+
+For each target domain, publish:
+
+- baseline success rate and confidence interval;
+- Fable V2 success rate and confidence interval;
+- relative success and error reduction;
+- successful tasks per token/dollar;
+- latency and tool-call counts;
+- verifier false-positive rate;
+- performance across at least two hosts and two model sizes.
+
+The weak-model 50x target is meaningful only when the baseline is non-zero
+and the absolute result is useful. The frontier-model 10x target should be
+reported primarily as reliability, failure reduction, or cost efficiency,
+because raw accuracy is bounded by 100%.

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -67,6 +67,21 @@ must never receive a full-guarantee status merely because it loaded a prompt.
 
 ## Enforcement model
 
+### Invocation is not correctness
+
+A `ToolReceipt` proves only that a host tool was invoked and what output it
+returned. For example, a successful `pytest` receipt proves that pytest ran
+successfully; it does **not** prove that the candidate is correct. Likewise,
+integrity-bound evidence proves provenance and content consistency, not that
+its claim is true.
+
+Correctness is established only by the verifier policy: deterministic tests,
+machine checks, independent review, hidden tests, or other explicitly
+registered checks. A receipt or evidence object must never be treated as a
+correctness verdict.
+
+### Receipt and evidence integrity
+
 A model-facing prompt cannot prove that a tool was used. Each host tool must
 produce a `ToolReceipt` containing:
 

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -165,6 +165,27 @@ behind the same verifier contract in `fable_v2/verifiers.py`.
 8. Publish results only after hidden evaluation; do not claim 10x/50x from
    plumbing tests.
 
+## Boundary-test coverage
+
+The foundation test suite covers failure modes that can silently turn a
+receipt ledger into a false correctness oracle:
+
+- cross-candidate and mismatched-evidence verification;
+- evidence/source hash mismatches;
+- duplicate or contradictory verifier results;
+- verifier invalidation after a prior pass;
+- malformed and reversed timestamps;
+- mutable metadata and artifact snapshotting;
+- run serialization round-trips;
+- concurrent candidate registration;
+- expected versus probed capability aliases;
+- verifier policy enforcement; and
+- tampered event-history detection.
+
+The suite is still a runtime-foundation suite. It does not replace real host
+adapters, sandbox tests, hidden task benchmarks, or calibration of model-based
+judges.
+
 ## Success criteria
 
 For each target domain, publish:

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -62,8 +62,13 @@ Supported integrations should be implemented as thin adapters, not forks of
 the cognitive engine. MCP is the preferred tool binding, but a CLI or HTTP
 adapter is required for hosts that do not expose MCP.
 
-An adapter must probe and advertise actual capabilities at startup. A host
-must never receive a full-guarantee status merely because it loaded a prompt.
+The checked-in `HOST_PROFILES` are explicitly **expected capability
+profiles**, not attestations. They are useful defaults for planning and
+documentation, but they are not runtime-authoritative. A live adapter must
+probe the host at startup and call `HostCapabilities.attest(...)` with the
+observed capabilities. Compatibility is authoritative only after that probe;
+a host must never receive a full-guarantee status merely because it loaded a
+prompt or matched a hard-coded profile.
 
 ## Enforcement model
 

--- a/fable_v2/__init__.py
+++ b/fable_v2/__init__.py
@@ -1,0 +1,12 @@
+"""Experimental portable Fable V2 runtime."""
+
+from .adapters import HOST_PROFILES, HostCapabilities, get_profile
+from .protocol import Candidate, Evidence, TaskSpec, ToolReceipt, VerificationResult
+from .runtime import FableRun, RunState, new_run
+from .verifiers import CompositeVerifier, FunctionVerifier
+
+__all__ = [
+    "Candidate", "CompositeVerifier", "Evidence", "FableRun",
+    "FunctionVerifier", "HOST_PROFILES", "HostCapabilities", "RunState",
+    "TaskSpec", "ToolReceipt", "VerificationResult", "get_profile", "new_run",
+]

--- a/fable_v2/__init__.py
+++ b/fable_v2/__init__.py
@@ -1,12 +1,20 @@
 """Experimental portable Fable V2 runtime."""
 
 from .adapters import HOST_PROFILES, HostCapabilities, get_profile
-from .protocol import Candidate, Evidence, TaskSpec, ToolReceipt, VerificationResult
+from .protocol import (
+    Candidate,
+    Evidence,
+    TaskSpec,
+    ToolReceipt,
+    VerificationPolicy,
+    VerificationResult,
+)
 from .runtime import FableRun, RunState, new_run
 from .verifiers import CompositeVerifier, FunctionVerifier
 
 __all__ = [
     "Candidate", "CompositeVerifier", "Evidence", "FableRun",
     "FunctionVerifier", "HOST_PROFILES", "HostCapabilities", "RunState",
-    "TaskSpec", "ToolReceipt", "VerificationResult", "get_profile", "new_run",
+    "TaskSpec", "ToolReceipt", "VerificationPolicy", "VerificationResult",
+    "get_profile", "new_run",
 ]

--- a/fable_v2/adapters.py
+++ b/fable_v2/adapters.py
@@ -1,0 +1,77 @@
+"""Thin host adapters for portable Fable V2 integrations.
+
+The profiles describe a contract, not a claim that every host currently
+supports every capability.  An adapter should probe the host at startup and
+only advertise capabilities it can actually provide.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class HostCapabilities:
+    host: str
+    capabilities: frozenset[str] = frozenset()
+    tool_aliases: Mapping[str, str] = field(default_factory=dict)
+
+    def supports(self, capability: str) -> bool:
+        return capability in self.capabilities
+
+    def normalize(self, tool_name: str) -> str:
+        return self.tool_aliases.get(tool_name, tool_name)
+
+    def compatibility_report(self, required: Iterable[str]) -> dict[str, object]:
+        required_set = set(required)
+        available = required_set & self.capabilities
+        missing = required_set - self.capabilities
+        return {
+            "host": self.host,
+            "compatible": not missing,
+            "required": sorted(required_set),
+            "available": sorted(available),
+            "missing": sorted(missing),
+        }
+
+
+# These are conservative baseline profiles.  Real adapters should replace
+# them after probing the host, rather than assuming a feature is available.
+HOST_PROFILES: dict[str, HostCapabilities] = {
+    "antigravity": HostCapabilities(
+        "antigravity",
+        frozenset({"inspect_files", "search_web", "execute_command", "edit_files",
+                   "run_tests", "delegate_agents"}),
+        {"run_command": "execute_command", "write_to_file": "edit_files"},
+    ),
+    "claude-code": HostCapabilities(
+        "claude-code",
+        frozenset({"inspect_files", "execute_command", "edit_files", "run_tests"}),
+        {"shell": "execute_command"},
+    ),
+    "codex": HostCapabilities(
+        "codex",
+        frozenset({"inspect_files", "execute_command", "edit_files", "run_tests"}),
+        {"shell": "execute_command"},
+    ),
+    "cursor": HostCapabilities(
+        "cursor",
+        frozenset({"inspect_files", "execute_command", "edit_files", "run_tests"}),
+        {"terminal": "execute_command"},
+    ),
+    "grok-build": HostCapabilities("grok-build"),
+    "zapia": HostCapabilities(
+        "zapia",
+        frozenset({"inspect_files", "search_web", "execute_command", "run_tests",
+                   "delegate_agents"}),
+    ),
+}
+
+
+def get_profile(host: str) -> HostCapabilities:
+    """Return a conservative profile; unknown hosts start with no claims."""
+    key = host.strip().lower()
+    if not key:
+        raise ValueError("host must be a non-empty string")
+    return HOST_PROFILES.get(key, HostCapabilities(key))

--- a/fable_v2/adapters.py
+++ b/fable_v2/adapters.py
@@ -13,31 +13,62 @@ from typing import Iterable, Mapping
 
 @dataclass(frozen=True)
 class HostCapabilities:
+    """Expected capabilities plus optional runtime-probed capabilities.
+
+    A profile is never authoritative until ``attest`` is called with the
+    result of a real host probe. This prevents documentation defaults from
+    silently becoming permission or compatibility claims.
+    """
+
     host: str
     capabilities: frozenset[str] = frozenset()
     tool_aliases: Mapping[str, str] = field(default_factory=dict)
+    observed_capabilities: frozenset[str] | None = None
+    source: str = "expected-profile"
 
-    def supports(self, capability: str) -> bool:
-        return capability in self.capabilities
+    @property
+    def is_attested(self) -> bool:
+        return self.observed_capabilities is not None
+
+    def supports(self, capability: str, *, authoritative: bool = False) -> bool:
+        available = self.observed_capabilities if self.is_attested else self.capabilities
+        return capability in available and (not authoritative or self.is_attested)
 
     def normalize(self, tool_name: str) -> str:
         return self.tool_aliases.get(tool_name, tool_name)
 
+    def attest(self, observed: Iterable[str], source: str = "host-probe") -> "HostCapabilities":
+        """Return a runtime-authoritative profile from actual probe results."""
+        observed_set = frozenset(str(item).strip() for item in observed if str(item).strip())
+        return HostCapabilities(
+            host=self.host,
+            capabilities=self.capabilities,
+            tool_aliases=self.tool_aliases,
+            observed_capabilities=observed_set,
+            source=source,
+        )
+
     def compatibility_report(self, required: Iterable[str]) -> dict[str, object]:
         required_set = set(required)
-        available = required_set & self.capabilities
-        missing = required_set - self.capabilities
+        expected = required_set & self.capabilities
+        available_set = self.observed_capabilities if self.is_attested else self.capabilities
+        available = required_set & available_set
+        missing = required_set - available_set
         return {
             "host": self.host,
-            "compatible": not missing,
+            "compatible": self.is_attested and not missing,
+            "authoritative": self.is_attested,
+            "capabilities_source": self.source,
             "required": sorted(required_set),
+            "expected": sorted(expected),
             "available": sorted(available),
             "missing": sorted(missing),
         }
 
 
-# These are conservative baseline profiles.  Real adapters should replace
-# them after probing the host, rather than assuming a feature is available.
+# These are conservative *expected* profiles. Real adapters must call
+# ``attest`` after probing the host; expected capabilities are never
+# runtime-authoritative.
 HOST_PROFILES: dict[str, HostCapabilities] = {
     "antigravity": HostCapabilities(
         "antigravity",

--- a/fable_v2/protocol.py
+++ b/fable_v2/protocol.py
@@ -53,8 +53,16 @@ class VerificationPolicy:
     required_verifier_classes: tuple[str, ...] = ("deterministic", "independent")
     minimum_passing_verifiers: int = 2
     require_independent: bool = True
+    # ``in_process`` is an application convention, not a security boundary.
+    # Production deployments should require ``process_attested`` and supply
+    # results from an isolated broker.
+    minimum_trust_boundary: str = "in_process"
+
+    TRUST_BOUNDARY_RANK = {"in_process": 0, "process_attested": 1}
 
     def __post_init__(self) -> None:
+        if self.minimum_trust_boundary not in self.TRUST_BOUNDARY_RANK:
+            raise ValueError("unsupported minimum_trust_boundary")
         if not self.required_verifier_classes:
             raise ValueError("verification policy must require at least one verifier class")
         if self.minimum_passing_verifiers < 1:
@@ -276,7 +284,9 @@ class VerificationResult:
     candidate_hash: str = ""
     inspected_candidate: bool = False
     independent: bool = False
-    trusted: bool = False
+    # ``in_process`` describes where the result came from; it is not proof of
+    # trust. Only an external broker may issue ``process_attested`` results.
+    trust_boundary: str = ""
     runtime_attestation: str = ""
 
     def __post_init__(self) -> None:

--- a/fable_v2/protocol.py
+++ b/fable_v2/protocol.py
@@ -93,11 +93,14 @@ class ToolReceipt:
     started_at: str
     finished_at: str
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    output: Any = None
 
     def __post_init__(self) -> None:
         for name in ("receipt_id", "session_id", "capability", "tool_name",
                      "input_hash", "output_hash", "started_at", "finished_at"):
             _required_text(getattr(self, name), name)
+        if canonical_hash(self.output) != self.output_hash:
+            raise ValueError("output_hash does not match the actual receipt output")
 
     @classmethod
     def from_result(
@@ -127,6 +130,7 @@ class ToolReceipt:
             started_at=start,
             finished_at=finish,
             metadata=metadata or {},
+            output=tool_output,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -135,7 +139,7 @@ class ToolReceipt:
 
 @dataclass(frozen=True)
 class Evidence:
-    """Evidence attached to a claim and anchored to a successful tool receipt."""
+    """Evidence whose content is integrity-bound to one successful receipt."""
 
     evidence_id: str
     session_id: str
@@ -146,11 +150,49 @@ class Evidence:
     content_hash: str
     verified: bool = False
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    content: Any = None
+    source_output_hash: str = ""
 
     def __post_init__(self) -> None:
         for name in ("evidence_id", "session_id", "claim", "kind", "source",
-                     "receipt_id", "content_hash"):
+                     "receipt_id", "content_hash", "source_output_hash"):
             _required_text(getattr(self, name), name)
+        if canonical_hash(self.content) != self.content_hash:
+            raise ValueError("content_hash does not match the evidence content")
+
+    @classmethod
+    def from_receipt(
+        cls,
+        receipt: ToolReceipt,
+        *,
+        evidence_id: str,
+        claim: str,
+        kind: str,
+        source: str,
+        verified: bool = False,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "Evidence":
+        """Create full-output evidence directly from a host receipt.
+
+        Keeping the receipt output in the content-addressed evidence object
+        makes the integrity relationship checkable. Large-output adapters can
+        replace ``content`` with a content-addressed blob in a later version.
+        """
+        if not receipt.success:
+            raise ValueError("evidence must be derived from a successful receipt")
+        return cls(
+            evidence_id=evidence_id,
+            session_id=receipt.session_id,
+            claim=claim,
+            kind=kind,
+            source=source,
+            receipt_id=receipt.receipt_id,
+            content_hash=receipt.output_hash,
+            verified=verified,
+            metadata=metadata or {},
+            content=receipt.output,
+            source_output_hash=receipt.output_hash,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/fable_v2/protocol.py
+++ b/fable_v2/protocol.py
@@ -1,0 +1,176 @@
+"""Portable, host-neutral objects used by the Fable V2 runtime.
+
+The protocol deliberately stores structured facts and tool receipts instead of
+asking a model to self-report that it performed work.  Hosts can bind their
+native tools to these objects through an adapter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+from typing import Any, Mapping
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def canonical_hash(value: Any) -> str:
+    """Return a stable SHA-256 hash for a JSON-compatible value."""
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _required_text(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    """The contract that defines what a run must accomplish."""
+
+    task_id: str
+    objective: str
+    constraints: tuple[str, ...] = ()
+    definition_of_done: tuple[str, ...] = ()
+    required_capabilities: tuple[str, ...] = ()
+    required_evidence: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _required_text(self.task_id, "task_id")
+        _required_text(self.objective, "objective")
+        if not self.definition_of_done:
+            raise ValueError("definition_of_done must contain at least one condition")
+        for item in (*self.constraints, *self.definition_of_done,
+                     *self.required_capabilities, *self.required_evidence):
+            _required_text(item, "task contract item")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ToolReceipt:
+    """A host-produced receipt proving that a capability was invoked."""
+
+    receipt_id: str
+    session_id: str
+    capability: str
+    tool_name: str
+    input_hash: str
+    output_hash: str
+    success: bool
+    started_at: str
+    finished_at: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in ("receipt_id", "session_id", "capability", "tool_name",
+                     "input_hash", "output_hash", "started_at", "finished_at"):
+            _required_text(getattr(self, name), name)
+
+    @classmethod
+    def from_result(
+        cls,
+        *,
+        receipt_id: str,
+        session_id: str,
+        capability: str,
+        tool_name: str,
+        tool_input: Any,
+        tool_output: Any,
+        success: bool,
+        started_at: str | None = None,
+        finished_at: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "ToolReceipt":
+        start = started_at or utc_now()
+        finish = finished_at or start
+        return cls(
+            receipt_id=receipt_id,
+            session_id=session_id,
+            capability=capability,
+            tool_name=tool_name,
+            input_hash=canonical_hash(tool_input),
+            output_hash=canonical_hash(tool_output),
+            success=bool(success),
+            started_at=start,
+            finished_at=finish,
+            metadata=metadata or {},
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """Evidence attached to a claim and anchored to a successful tool receipt."""
+
+    evidence_id: str
+    session_id: str
+    claim: str
+    kind: str
+    source: str
+    receipt_id: str
+    content_hash: str
+    verified: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in ("evidence_id", "session_id", "claim", "kind", "source",
+                     "receipt_id", "content_hash"):
+            _required_text(getattr(self, name), name)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One independently generated solution or trajectory."""
+
+    candidate_id: str
+    session_id: str
+    approach: str
+    artifact: Any
+    receipt_ids: tuple[str, ...] = ()
+    evidence_ids: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in ("candidate_id", "session_id", "approach"):
+            _required_text(getattr(self, name), name)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """The result of a deterministic or independent model-based verifier."""
+
+    verification_id: str
+    session_id: str
+    candidate_id: str
+    verifier: str
+    passed: bool
+    reasons: tuple[str, ...] = ()
+    evidence_ids: tuple[str, ...] = ()
+    score: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in ("verification_id", "session_id", "candidate_id", "verifier"):
+            _required_text(getattr(self, name), name)
+        if self.score is not None and not 0 <= self.score <= 1:
+            raise ValueError("score must be between 0 and 1")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/fable_v2/protocol.py
+++ b/fable_v2/protocol.py
@@ -297,6 +297,3 @@ class VerificationResult:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)

--- a/fable_v2/protocol.py
+++ b/fable_v2/protocol.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+import copy
 import hashlib
 import json
 from typing import Any, Mapping
@@ -28,6 +29,18 @@ def _required_text(value: str, field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{field_name} must be a non-empty string")
     return value.strip()
+
+
+def _parse_timestamp(value: str, field_name: str) -> datetime:
+    text = _required_text(value, field_name)
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{field_name} must include a timezone offset")
+    return parsed
 
 
 @dataclass(frozen=True)
@@ -103,6 +116,14 @@ class ToolReceipt:
         for name in ("receipt_id", "session_id", "capability", "tool_name",
                      "input_hash", "output_hash", "started_at", "finished_at"):
             _required_text(getattr(self, name), name)
+        started = _parse_timestamp(self.started_at, "started_at")
+        finished = _parse_timestamp(self.finished_at, "finished_at")
+        if finished < started:
+            raise ValueError("finished_at cannot be earlier than started_at")
+        # Snapshot mutable host payloads so later caller mutation cannot change
+        # what the receipt hashes or what evidence derives from it.
+        object.__setattr__(self, "output", copy.deepcopy(self.output))
+        object.__setattr__(self, "metadata", copy.deepcopy(dict(self.metadata)))
         if canonical_hash(self.output) != self.output_hash:
             raise ValueError("output_hash does not match the actual receipt output")
 
@@ -164,6 +185,8 @@ class Evidence:
         for name in ("evidence_id", "session_id", "claim", "kind", "source",
                      "receipt_id", "content_hash", "source_output_hash"):
             _required_text(getattr(self, name), name)
+        object.__setattr__(self, "content", copy.deepcopy(self.content))
+        object.__setattr__(self, "metadata", copy.deepcopy(dict(self.metadata)))
         if canonical_hash(self.content) != self.content_hash:
             raise ValueError("content_hash does not match the evidence content")
 

--- a/fable_v2/protocol.py
+++ b/fable_v2/protocol.py
@@ -81,7 +81,11 @@ class TaskSpec:
 
 @dataclass(frozen=True)
 class ToolReceipt:
-    """A host-produced receipt proving that a capability was invoked."""
+    """A host-produced receipt proving invocation and captured output.
+
+    ``success`` means the tool call completed successfully. It is not a claim
+    that the output is correct or that the candidate is correct.
+    """
 
     receipt_id: str
     session_id: str
@@ -139,7 +143,11 @@ class ToolReceipt:
 
 @dataclass(frozen=True)
 class Evidence:
-    """Evidence whose content is integrity-bound to one successful receipt."""
+    """Captured evidence integrity-bound to one successful receipt.
+
+    Integrity binding proves provenance and content consistency only. It does
+    not prove that the claim is true; a verifier must establish that.
+    """
 
     evidence_id: str
     session_id: str
@@ -148,7 +156,6 @@ class Evidence:
     source: str
     receipt_id: str
     content_hash: str
-    verified: bool = False
     metadata: Mapping[str, Any] = field(default_factory=dict)
     content: Any = None
     source_output_hash: str = ""
@@ -160,6 +167,14 @@ class Evidence:
         if canonical_hash(self.content) != self.content_hash:
             raise ValueError("content_hash does not match the evidence content")
 
+    @property
+    def integrity_bound(self) -> bool:
+        """Whether provenance and content hashes agree; not claim truth."""
+        return (
+            canonical_hash(self.content) == self.content_hash
+            and self.content_hash == self.source_output_hash
+        )
+
     @classmethod
     def from_receipt(
         cls,
@@ -169,7 +184,6 @@ class Evidence:
         claim: str,
         kind: str,
         source: str,
-        verified: bool = False,
         metadata: Mapping[str, Any] | None = None,
     ) -> "Evidence":
         """Create full-output evidence directly from a host receipt.
@@ -188,7 +202,6 @@ class Evidence:
             source=source,
             receipt_id=receipt.receipt_id,
             content_hash=receipt.output_hash,
-            verified=verified,
             metadata=metadata or {},
             content=receipt.output,
             source_output_hash=receipt.output_hash,

--- a/fable_v2/protocol.py
+++ b/fable_v2/protocol.py
@@ -31,6 +31,29 @@ def _required_text(value: str, field_name: str) -> str:
 
 
 @dataclass(frozen=True)
+class VerificationPolicy:
+    """Acceptance policy declared by the task, not by the model."""
+
+    # The default policy requires both an objective/deterministic check and a
+    # separately registered independent check. Tasks may explicitly choose a
+    # narrower policy when no independent check is meaningful.
+    required_verifier_classes: tuple[str, ...] = ("deterministic", "independent")
+    minimum_passing_verifiers: int = 2
+    require_independent: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.required_verifier_classes:
+            raise ValueError("verification policy must require at least one verifier class")
+        if self.minimum_passing_verifiers < 1:
+            raise ValueError("minimum_passing_verifiers must be at least 1")
+        for item in self.required_verifier_classes:
+            _required_text(item, "verifier class")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class TaskSpec:
     """The contract that defines what a run must accomplish."""
 
@@ -40,6 +63,7 @@ class TaskSpec:
     definition_of_done: tuple[str, ...] = ()
     required_capabilities: tuple[str, ...] = ()
     required_evidence: tuple[str, ...] = ()
+    verification_policy: VerificationPolicy = field(default_factory=VerificationPolicy)
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -154,7 +178,12 @@ class Candidate:
 
 @dataclass(frozen=True)
 class VerificationResult:
-    """The result of a deterministic or independent model-based verifier."""
+    """A runtime-attested verifier result.
+
+    The attestation and candidate hash are populated by ``FableRun`` after a
+    registered verifier is executed. Callers must not construct a passing
+    result and submit it directly to the run.
+    """
 
     verification_id: str
     session_id: str
@@ -165,12 +194,21 @@ class VerificationResult:
     evidence_ids: tuple[str, ...] = ()
     score: float | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    verifier_class: str = ""
+    candidate_hash: str = ""
+    inspected_candidate: bool = False
+    independent: bool = False
+    trusted: bool = False
+    runtime_attestation: str = ""
 
     def __post_init__(self) -> None:
         for name in ("verification_id", "session_id", "candidate_id", "verifier"):
             _required_text(getattr(self, name), name)
         if self.score is not None and not 0 <= self.score <= 1:
             raise ValueError("score must be between 0 and 1")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -106,6 +106,10 @@ class FableRun:
             raise ValueError("evidence must reference a known tool receipt")
         if not receipt.success:
             raise ValueError("evidence cannot be anchored to a failed tool call")
+        if evidence.source_output_hash != receipt.output_hash:
+            raise PermissionError("evidence is not bound to the receipt output hash")
+        if evidence.content_hash != receipt.output_hash:
+            raise PermissionError("evidence content hash does not match receipt output hash")
         if evidence.evidence_id in self.evidence:
             raise ValueError(f"duplicate evidence: {evidence.evidence_id}")
         self.evidence[evidence.evidence_id] = evidence

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -7,11 +7,38 @@ acceptance gates that a host adapter and verifier must satisfy.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import Any, Iterable
+import hashlib
+import hmac
+import secrets
+from typing import Any, Callable, Iterable, Protocol
 
-from .protocol import Candidate, Evidence, TaskSpec, ToolReceipt, VerificationResult, utc_now
+from .protocol import (
+    Candidate,
+    Evidence,
+    TaskSpec,
+    ToolReceipt,
+    VerificationResult,
+    canonical_hash,
+    utc_now,
+)
+
+
+class RegisteredVerifier(Protocol):
+    """A verifier registered by trusted runtime code.
+
+    ``verify`` must inspect the supplied candidate and return an un-attested
+    result. The runtime stamps its identity and candidate hash afterwards.
+    """
+
+    name: str
+    verifier_class: str
+    independent: bool
+    trusted: bool
+
+    def verify(self, candidate: Candidate) -> VerificationResult:
+        ...
 
 
 class RunState(str, Enum):
@@ -36,6 +63,8 @@ class FableRun:
     verifications: dict[str, VerificationResult] = field(default_factory=dict)
     events: list[dict[str, Any]] = field(default_factory=list)
     final_candidate_id: str | None = None
+    _attestation_secret: bytes = field(default_factory=lambda: secrets.token_bytes(32),
+                                       repr=False)
 
     def _event(self, event_type: str, **data: Any) -> None:
         self.events.append({"type": event_type, "at": utc_now(), **data})
@@ -83,20 +112,77 @@ class FableRun:
         self._event("evidence_attached", evidence_id=evidence.evidence_id,
                     receipt_id=evidence.receipt_id)
 
-    def record_verification(self, result: VerificationResult) -> None:
+    def _record_attested_verification(self, result: VerificationResult) -> None:
+        """Store a result after ``execute_verifier`` has attested it."""
         if result.session_id != self.session_id:
             raise ValueError("verification belongs to a different session")
-        if result.candidate_id not in self.candidates:
+        candidate = self.candidates.get(result.candidate_id)
+        if candidate is None:
             raise ValueError("verification references an unknown candidate")
         if result.verification_id in self.verifications:
             raise ValueError(f"duplicate verification: {result.verification_id}")
+        if not result.trusted or not result.inspected_candidate:
+            raise PermissionError("verification must be produced by a trusted registered verifier")
+        if result.candidate_hash != canonical_hash(candidate.artifact):
+            raise PermissionError("verification was not produced for the current candidate artifact")
+        expected = self._attestation(result)
+        if not hmac.compare_digest(result.runtime_attestation, expected):
+            raise PermissionError("verification has no valid runtime attestation")
         unknown_evidence = [eid for eid in result.evidence_ids if eid not in self.evidence]
         if unknown_evidence:
             raise ValueError(f"verification references unknown evidence: {unknown_evidence}")
         self.state = RunState.VERIFYING
         self.verifications[result.verification_id] = result
         self._event("verification_recorded", verification_id=result.verification_id,
-                    candidate_id=result.candidate_id, passed=result.passed)
+                    candidate_id=result.candidate_id, verifier=result.verifier,
+                    verifier_class=result.verifier_class, passed=result.passed)
+
+    def record_verification(self, result: VerificationResult) -> None:
+        """Reject untrusted/model-supplied results.
+
+        Results must come from ``execute_verifier`` so the runtime can bind the
+        verdict to a registered verifier and the exact candidate artifact.
+        """
+        raise PermissionError(
+            "direct verification recording is disabled; execute a registered verifier"
+        )
+
+    def _attestation(self, result: VerificationResult) -> str:
+        payload = "|".join((result.verification_id, result.candidate_id,
+                             result.candidate_hash, result.verifier,
+                             result.verifier_class))
+        return hmac.new(self._attestation_secret, payload.encode("utf-8"),
+                        hashlib.sha256).hexdigest()
+
+    def execute_verifier(self, verifier: RegisteredVerifier, candidate_id: str) -> VerificationResult:
+        """Run and attest a registered verifier against one exact candidate.
+
+        Trust and independence are properties of runtime registration, never
+        free-form fields supplied by a model-facing result.
+        """
+        candidate = self.candidates.get(candidate_id)
+        if candidate is None:
+            raise ValueError(f"unknown candidate: {candidate_id}")
+        if not getattr(verifier, "trusted", False):
+            raise PermissionError(f"verifier is not trusted: {getattr(verifier, 'name', '')}")
+        verifier_class = str(getattr(verifier, "verifier_class", "")).strip()
+        if not verifier_class:
+            raise ValueError("registered verifier must declare verifier_class")
+        raw = verifier.verify(candidate)
+        if raw.candidate_id != candidate_id or raw.session_id != self.session_id:
+            raise ValueError("verifier returned a result for the wrong session or candidate")
+        result = replace(
+            raw,
+            verifier=getattr(verifier, "name", raw.verifier),
+            verifier_class=verifier_class,
+            candidate_hash=canonical_hash(candidate.artifact),
+            inspected_candidate=True,
+            independent=bool(getattr(verifier, "independent", False)),
+            trusted=True,
+        )
+        result = replace(result, runtime_attestation=self._attestation(result))
+        self._record_attested_verification(result)
+        return result
 
     def successful_capabilities(self) -> set[str]:
         return {r.capability for r in self.receipts.values() if r.success}
@@ -120,21 +206,36 @@ class FableRun:
 
     def passed_verifications(self, candidate_id: str) -> list[VerificationResult]:
         return [v for v in self.verifications.values()
-                if v.candidate_id == candidate_id and v.passed]
+                if v.candidate_id == candidate_id and v.passed and v.trusted
+                and v.inspected_candidate]
+
+    def verification_requirements(self, candidate_id: str) -> list[str]:
+        """Return missing policy requirements for the exact candidate."""
+        passed = self.passed_verifications(candidate_id)
+        policy = self.task.verification_policy
+        classes = {v.verifier_class for v in passed}
+        missing = [
+            f"required verifier class not passed: {kind}"
+            for kind in policy.required_verifier_classes
+            if kind not in classes
+        ]
+        if len(passed) < policy.minimum_passing_verifiers:
+            missing.append(
+                f"requires {policy.minimum_passing_verifiers} passing verifiers "
+                f"(currently {len(passed)})"
+            )
+        if policy.require_independent and not any(v.independent for v in passed):
+            missing.append("requires a passing independently registered verifier")
+        return missing
 
     def finalize(self, candidate_id: str) -> Candidate:
         if candidate_id not in self.candidates:
             raise ValueError(f"unknown candidate: {candidate_id}")
-        missing = self.missing_requirements(candidate_id)
+        missing = self.missing_requirements(candidate_id) + self.verification_requirements(candidate_id)
         if missing:
             self.state = RunState.REJECTED
             self._event("finalization_rejected", candidate_id=candidate_id, missing=missing)
             raise PermissionError("finalization rejected: " + "; ".join(missing))
-        if not self.passed_verifications(candidate_id):
-            self.state = RunState.REJECTED
-            self._event("finalization_rejected", candidate_id=candidate_id,
-                        missing=["a passing independent verification"])
-            raise PermissionError("finalization rejected: no passing verification")
         self.final_candidate_id = candidate_id
         self.state = RunState.FINALIZED
         self._event("run_finalized", candidate_id=candidate_id)
@@ -150,7 +251,12 @@ class FableRun:
             "evidence": len(self.evidence),
             "verifications": len(self.verifications),
             "successful_capabilities": sorted(self.successful_capabilities()),
-            "missing_requirements": self.missing_requirements(self.final_candidate_id),
+            "missing_requirements": (
+                self.missing_requirements(self.final_candidate_id)
+                + (self.verification_requirements(self.final_candidate_id)
+                   if self.final_candidate_id else [])
+            ),
+            "verification_policy": self.task.verification_policy.to_dict(),
             "final_candidate_id": self.final_candidate_id,
         }
 

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -29,16 +29,17 @@ from .protocol import (
 
 
 class RegisteredVerifier(Protocol):
-    """A verifier registered by trusted runtime code.
+    """A verifier invoked through the in-process foundation API.
 
     ``verify`` must inspect the supplied candidate and return an un-attested
     result. The runtime stamps its identity and candidate hash afterwards.
+    In-process registration is not a security boundary.
     """
 
     name: str
     verifier_class: str
     independent: bool
-    trusted: bool
+    trust_boundary: str
 
     def verify(self, candidate: Candidate) -> VerificationResult:
         ...
@@ -163,8 +164,10 @@ class FableRun:
         if any(v.candidate_id == result.candidate_id and v.verifier == result.verifier
                for v in self.verifications.values()):
             raise ValueError("verifier already produced a result for this candidate")
-        if not result.trusted or not result.inspected_candidate:
-            raise PermissionError("verification must be produced by a trusted registered verifier")
+        if not result.inspected_candidate:
+            raise PermissionError("verification must be produced by an executed verifier")
+        if result.trust_boundary not in VerificationPolicy.TRUST_BOUNDARY_RANK:
+            raise PermissionError("verification has no recognized trust boundary")
         if result.candidate_hash != canonical_hash(candidate.artifact):
             raise PermissionError("verification was not produced for the current candidate artifact")
         expected = self._attestation(result)
@@ -189,10 +192,11 @@ class FableRun:
                     verifier_class=result.verifier_class, passed=result.passed)
 
     def record_verification(self, result: VerificationResult) -> None:
-        """Reject untrusted/model-supplied results.
+        """Reject model-supplied or otherwise unattested results.
 
         Results must come from ``execute_verifier`` so the runtime can bind the
-        verdict to a registered verifier and the exact candidate artifact.
+        verdict to an in-process verifier invocation and the exact candidate
+        artifact. This is an integrity boundary, not a process trust boundary.
         """
         raise PermissionError(
             "direct verification recording is disabled; execute a registered verifier"
@@ -201,24 +205,33 @@ class FableRun:
     def _attestation(self, result: VerificationResult) -> str:
         payload = "|".join((result.verification_id, result.candidate_id,
                              result.candidate_hash, result.verifier,
-                             result.verifier_class))
+                             result.verifier_class, result.trust_boundary))
         return hmac.new(self._attestation_secret, payload.encode("utf-8"),
                         hashlib.sha256).hexdigest()
 
     def execute_verifier(self, verifier: RegisteredVerifier, candidate_id: str) -> VerificationResult:
-        """Run and attest a registered verifier against one exact candidate.
+        """Run and attest an in-process verifier against one exact candidate.
 
-        Trust and independence are properties of runtime registration, never
-        free-form fields supplied by a model-facing result.
+        The runtime binds the result to the invocation and artifact. The
+        caller's in-process code is still within the same trust domain; a
+        stronger boundary requires an isolated broker result.
         """
         candidate = self.candidates.get(candidate_id)
         if candidate is None:
             raise ValueError(f"unknown candidate: {candidate_id}")
         verifier_name = str(getattr(verifier, "name", "")).strip()
+        if not verifier_name:
+            raise ValueError("registered verifier must declare a name")
         if verifier_name in self.invalidated_verifiers:
             raise PermissionError(f"verifier is invalidated: {verifier_name}")
-        if not getattr(verifier, "trusted", False):
-            raise PermissionError(f"verifier is not trusted: {verifier_name}")
+        # In-process verifier objects are application-level declarations only.
+        # A process-attested result must arrive from an isolated broker path;
+        # this method deliberately refuses to stamp that stronger boundary.
+        trust_boundary = str(getattr(verifier, "trust_boundary", "")).strip()
+        if trust_boundary != "in_process":
+            raise PermissionError(
+                "in-process verifier execution cannot claim a process-attested boundary"
+            )
         verifier_class = str(getattr(verifier, "verifier_class", "")).strip()
         if not verifier_class:
             raise ValueError("registered verifier must declare verifier_class")
@@ -246,7 +259,7 @@ class FableRun:
             candidate_hash=canonical_hash(candidate.artifact),
             inspected_candidate=True,
             independent=bool(getattr(verifier, "independent", False)),
-            trusted=True,
+            trust_boundary=trust_boundary,
         )
         result = replace(result, runtime_attestation=self._attestation(result))
         self._record_attested_verification(result)
@@ -283,8 +296,10 @@ class FableRun:
 
     def passed_verifications(self, candidate_id: str) -> list[VerificationResult]:
         return [v for v in self.verifications.values()
-                if v.candidate_id == candidate_id and v.passed and v.trusted
-                and v.inspected_candidate and v.verifier not in self.invalidated_verifiers]
+                if v.candidate_id == candidate_id and v.passed
+                and v.inspected_candidate
+                and v.trust_boundary in VerificationPolicy.TRUST_BOUNDARY_RANK
+                and v.verifier not in self.invalidated_verifiers]
 
     def verification_requirements(self, candidate_id: str) -> list[str]:
         """Return missing policy requirements for the exact candidate."""
@@ -303,6 +318,13 @@ class FableRun:
             )
         if policy.require_independent and not any(v.independent for v in passed):
             missing.append("requires a passing independently registered verifier")
+        boundary_rank = VerificationPolicy.TRUST_BOUNDARY_RANK[policy.minimum_trust_boundary]
+        if not any(VerificationPolicy.TRUST_BOUNDARY_RANK[v.trust_boundary] >= boundary_rank
+                   for v in passed):
+            missing.append(
+                "requires a passing verifier at trust boundary "
+                + policy.minimum_trust_boundary
+            )
         return missing
 
     def finalize(self, candidate_id: str) -> Candidate:

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -1,0 +1,161 @@
+"""Evidence-gated, host-neutral Fable V2 runtime.
+
+This module is intentionally model-agnostic.  It does not pretend that a
+prompt or MCP call makes a result correct; it provides the state machine and
+acceptance gates that a host adapter and verifier must satisfy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable
+
+from .protocol import Candidate, Evidence, TaskSpec, ToolReceipt, VerificationResult, utc_now
+
+
+class RunState(str, Enum):
+    CREATED = "created"
+    ACTIVE = "active"
+    VERIFYING = "verifying"
+    FINALIZED = "finalized"
+    REJECTED = "rejected"
+
+
+@dataclass
+class FableRun:
+    """A single auditable task run."""
+
+    session_id: str
+    task: TaskSpec
+    state: RunState = RunState.CREATED
+    started_at: str = field(default_factory=utc_now)
+    receipts: dict[str, ToolReceipt] = field(default_factory=dict)
+    candidates: dict[str, Candidate] = field(default_factory=dict)
+    evidence: dict[str, Evidence] = field(default_factory=dict)
+    verifications: dict[str, VerificationResult] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    final_candidate_id: str | None = None
+
+    def _event(self, event_type: str, **data: Any) -> None:
+        self.events.append({"type": event_type, "at": utc_now(), **data})
+
+    def start(self) -> None:
+        if self.state is not RunState.CREATED:
+            raise RuntimeError(f"run is already {self.state.value}")
+        self.state = RunState.ACTIVE
+        self._event("run_started", session_id=self.session_id)
+
+    def record_receipt(self, receipt: ToolReceipt) -> None:
+        if receipt.session_id != self.session_id:
+            raise ValueError("tool receipt belongs to a different session")
+        if receipt.receipt_id in self.receipts:
+            raise ValueError(f"duplicate receipt: {receipt.receipt_id}")
+        self.receipts[receipt.receipt_id] = receipt
+        self._event("tool_receipt", receipt_id=receipt.receipt_id,
+                    capability=receipt.capability, success=receipt.success)
+
+    def register_candidate(self, candidate: Candidate) -> None:
+        if candidate.session_id != self.session_id:
+            raise ValueError("candidate belongs to a different session")
+        if candidate.candidate_id in self.candidates:
+            raise ValueError(f"duplicate candidate: {candidate.candidate_id}")
+        missing = [rid for rid in candidate.receipt_ids if rid not in self.receipts]
+        if missing:
+            raise ValueError(f"candidate references unknown receipts: {missing}")
+        missing_evidence = [eid for eid in candidate.evidence_ids if eid not in self.evidence]
+        if missing_evidence:
+            raise ValueError(f"candidate references unknown evidence: {missing_evidence}")
+        self.candidates[candidate.candidate_id] = candidate
+        self._event("candidate_registered", candidate_id=candidate.candidate_id)
+
+    def attach_evidence(self, evidence: Evidence) -> None:
+        if evidence.session_id != self.session_id:
+            raise ValueError("evidence belongs to a different session")
+        receipt = self.receipts.get(evidence.receipt_id)
+        if receipt is None:
+            raise ValueError("evidence must reference a known tool receipt")
+        if not receipt.success:
+            raise ValueError("evidence cannot be anchored to a failed tool call")
+        if evidence.evidence_id in self.evidence:
+            raise ValueError(f"duplicate evidence: {evidence.evidence_id}")
+        self.evidence[evidence.evidence_id] = evidence
+        self._event("evidence_attached", evidence_id=evidence.evidence_id,
+                    receipt_id=evidence.receipt_id)
+
+    def record_verification(self, result: VerificationResult) -> None:
+        if result.session_id != self.session_id:
+            raise ValueError("verification belongs to a different session")
+        if result.candidate_id not in self.candidates:
+            raise ValueError("verification references an unknown candidate")
+        if result.verification_id in self.verifications:
+            raise ValueError(f"duplicate verification: {result.verification_id}")
+        unknown_evidence = [eid for eid in result.evidence_ids if eid not in self.evidence]
+        if unknown_evidence:
+            raise ValueError(f"verification references unknown evidence: {unknown_evidence}")
+        self.state = RunState.VERIFYING
+        self.verifications[result.verification_id] = result
+        self._event("verification_recorded", verification_id=result.verification_id,
+                    candidate_id=result.candidate_id, passed=result.passed)
+
+    def successful_capabilities(self) -> set[str]:
+        return {r.capability for r in self.receipts.values() if r.success}
+
+    def missing_requirements(self, candidate_id: str | None = None) -> list[str]:
+        missing: list[str] = []
+        used = self.successful_capabilities()
+        for capability in self.task.required_capabilities:
+            if capability not in used:
+                missing.append(f"required capability not completed: {capability}")
+
+        if self.task.required_evidence:
+            candidate_evidence = set()
+            if candidate_id and candidate_id in self.candidates:
+                candidate_evidence = set(self.candidates[candidate_id].evidence_ids)
+            for kind in self.task.required_evidence:
+                if not any(e.kind == kind and e.evidence_id in candidate_evidence
+                           for e in self.evidence.values()):
+                    missing.append(f"required evidence not attached: {kind}")
+        return missing
+
+    def passed_verifications(self, candidate_id: str) -> list[VerificationResult]:
+        return [v for v in self.verifications.values()
+                if v.candidate_id == candidate_id and v.passed]
+
+    def finalize(self, candidate_id: str) -> Candidate:
+        if candidate_id not in self.candidates:
+            raise ValueError(f"unknown candidate: {candidate_id}")
+        missing = self.missing_requirements(candidate_id)
+        if missing:
+            self.state = RunState.REJECTED
+            self._event("finalization_rejected", candidate_id=candidate_id, missing=missing)
+            raise PermissionError("finalization rejected: " + "; ".join(missing))
+        if not self.passed_verifications(candidate_id):
+            self.state = RunState.REJECTED
+            self._event("finalization_rejected", candidate_id=candidate_id,
+                        missing=["a passing independent verification"])
+            raise PermissionError("finalization rejected: no passing verification")
+        self.final_candidate_id = candidate_id
+        self.state = RunState.FINALIZED
+        self._event("run_finalized", candidate_id=candidate_id)
+        return self.candidates[candidate_id]
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "task_id": self.task.task_id,
+            "state": self.state.value,
+            "receipts": len(self.receipts),
+            "candidates": len(self.candidates),
+            "evidence": len(self.evidence),
+            "verifications": len(self.verifications),
+            "successful_capabilities": sorted(self.successful_capabilities()),
+            "missing_requirements": self.missing_requirements(self.final_candidate_id),
+            "final_candidate_id": self.final_candidate_id,
+        }
+
+
+def new_run(session_id: str, task: TaskSpec) -> FableRun:
+    run = FableRun(session_id=session_id, task=task)
+    run.start()
+    return run

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -131,6 +131,15 @@ class FableRun:
         unknown_evidence = [eid for eid in result.evidence_ids if eid not in self.evidence]
         if unknown_evidence:
             raise ValueError(f"verification references unknown evidence: {unknown_evidence}")
+        candidate_evidence = set(candidate.evidence_ids)
+        unrelated_evidence = [eid for eid in result.evidence_ids if eid not in candidate_evidence]
+        if unrelated_evidence:
+            raise PermissionError(
+                "verification evidence is not attached to the verified candidate: "
+                + ", ".join(unrelated_evidence)
+            )
+        if result.passed and not result.evidence_ids:
+            raise PermissionError("a passing verification must cite candidate evidence")
         self.state = RunState.VERIFYING
         self.verifications[result.verification_id] = result
         self._event("verification_recorded", verification_id=result.verification_id,
@@ -168,6 +177,20 @@ class FableRun:
         verifier_class = str(getattr(verifier, "verifier_class", "")).strip()
         if not verifier_class:
             raise ValueError("registered verifier must declare verifier_class")
+        # Objective checks must establish a baseline before an independent
+        # judge is allowed to approve the candidate. This prevents a model
+        # judge from becoming the first and only line of defense.
+        deterministic_classes = {"deterministic", "machine-check"}
+        required_deterministic = deterministic_classes & set(
+            self.task.verification_policy.required_verifier_classes
+        )
+        passed_classes = {v.verifier_class for v in self.passed_verifications(candidate_id)}
+        if (bool(getattr(verifier, "independent", False))
+                and required_deterministic - passed_classes):
+            raise PermissionError(
+                "independent verification must run after passing deterministic "
+                "verification: " + ", ".join(sorted(required_deterministic - passed_classes))
+            )
         raw = verifier.verify(candidate)
         if raw.candidate_id != candidate_id or raw.session_id != self.session_id:
             raise ValueError("verifier returned a result for the wrong session or candidate")

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -9,16 +9,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 from enum import Enum
+import copy
 import hashlib
 import hmac
 import secrets
-from typing import Any, Callable, Iterable, Protocol
+import threading
+from typing import Any, Iterable, Protocol
 
 from .protocol import (
     Candidate,
     Evidence,
     TaskSpec,
     ToolReceipt,
+    VerificationPolicy,
     VerificationResult,
     canonical_hash,
     utc_now,
@@ -63,11 +66,30 @@ class FableRun:
     verifications: dict[str, VerificationResult] = field(default_factory=dict)
     events: list[dict[str, Any]] = field(default_factory=list)
     final_candidate_id: str | None = None
+    invalidated_verifiers: dict[str, str] = field(default_factory=dict)
     _attestation_secret: bytes = field(default_factory=lambda: secrets.token_bytes(32),
                                        repr=False)
+    _lock: threading.RLock = field(default_factory=threading.RLock,
+                                    repr=False, compare=False)
 
     def _event(self, event_type: str, **data: Any) -> None:
-        self.events.append({"type": event_type, "at": utc_now(), **data})
+        with self._lock:
+            event = {"type": event_type, "at": utc_now(), **data}
+            event["prev_hash"] = self.events[-1].get("event_hash", "0" * 64) if self.events else "0" * 64
+            event["event_hash"] = canonical_hash(event)
+            self.events.append(event)
+
+    def validate_event_history(self) -> None:
+        """Reject edited, reordered, or truncated event history."""
+        previous = "0" * 64
+        for event in self.events:
+            if event.get("prev_hash") != previous:
+                raise ValueError("event history chain is broken")
+            supplied_hash = event.get("event_hash")
+            body = {key: value for key, value in event.items() if key != "event_hash"}
+            if supplied_hash != canonical_hash(body):
+                raise ValueError("event history contains a tampered event")
+            previous = supplied_hash
 
     def start(self) -> None:
         if self.state is not RunState.CREATED:
@@ -76,29 +98,42 @@ class FableRun:
         self._event("run_started", session_id=self.session_id)
 
     def record_receipt(self, receipt: ToolReceipt) -> None:
-        if receipt.session_id != self.session_id:
-            raise ValueError("tool receipt belongs to a different session")
-        if receipt.receipt_id in self.receipts:
-            raise ValueError(f"duplicate receipt: {receipt.receipt_id}")
-        self.receipts[receipt.receipt_id] = receipt
-        self._event("tool_receipt", receipt_id=receipt.receipt_id,
-                    capability=receipt.capability, success=receipt.success)
+        with self._lock:
+            if receipt.session_id != self.session_id:
+                raise ValueError("tool receipt belongs to a different session")
+            if receipt.receipt_id in self.receipts:
+                raise ValueError(f"duplicate receipt: {receipt.receipt_id}")
+            self.receipts[receipt.receipt_id] = receipt
+            self._event("tool_receipt", receipt_id=receipt.receipt_id,
+                        capability=receipt.capability, success=receipt.success)
 
     def register_candidate(self, candidate: Candidate) -> None:
-        if candidate.session_id != self.session_id:
-            raise ValueError("candidate belongs to a different session")
-        if candidate.candidate_id in self.candidates:
-            raise ValueError(f"duplicate candidate: {candidate.candidate_id}")
-        missing = [rid for rid in candidate.receipt_ids if rid not in self.receipts]
-        if missing:
-            raise ValueError(f"candidate references unknown receipts: {missing}")
-        missing_evidence = [eid for eid in candidate.evidence_ids if eid not in self.evidence]
-        if missing_evidence:
-            raise ValueError(f"candidate references unknown evidence: {missing_evidence}")
-        self.candidates[candidate.candidate_id] = candidate
-        self._event("candidate_registered", candidate_id=candidate.candidate_id)
+        with self._lock:
+            if candidate.session_id != self.session_id:
+                raise ValueError("candidate belongs to a different session")
+            if candidate.candidate_id in self.candidates:
+                raise ValueError(f"duplicate candidate: {candidate.candidate_id}")
+            missing = [rid for rid in candidate.receipt_ids if rid not in self.receipts]
+            if missing:
+                raise ValueError(f"candidate references unknown receipts: {missing}")
+            missing_evidence = [eid for eid in candidate.evidence_ids if eid not in self.evidence]
+            if missing_evidence:
+                raise ValueError(f"candidate references unknown evidence: {missing_evidence}")
+            # Keep a private snapshot so callers cannot mutate an artifact or
+            # metadata after it enters the auditable run.
+            stored = replace(
+                candidate,
+                artifact=copy.deepcopy(candidate.artifact),
+                metadata=copy.deepcopy(dict(candidate.metadata)),
+            )
+            self.candidates[candidate.candidate_id] = stored
+            self._event("candidate_registered", candidate_id=candidate.candidate_id)
 
     def attach_evidence(self, evidence: Evidence) -> None:
+        with self._lock:
+            self._attach_evidence(evidence)
+
+    def _attach_evidence(self, evidence: Evidence) -> None:
         if evidence.session_id != self.session_id:
             raise ValueError("evidence belongs to a different session")
         receipt = self.receipts.get(evidence.receipt_id)
@@ -125,6 +160,9 @@ class FableRun:
             raise ValueError("verification references an unknown candidate")
         if result.verification_id in self.verifications:
             raise ValueError(f"duplicate verification: {result.verification_id}")
+        if any(v.candidate_id == result.candidate_id and v.verifier == result.verifier
+               for v in self.verifications.values()):
+            raise ValueError("verifier already produced a result for this candidate")
         if not result.trusted or not result.inspected_candidate:
             raise PermissionError("verification must be produced by a trusted registered verifier")
         if result.candidate_hash != canonical_hash(candidate.artifact):
@@ -176,8 +214,11 @@ class FableRun:
         candidate = self.candidates.get(candidate_id)
         if candidate is None:
             raise ValueError(f"unknown candidate: {candidate_id}")
+        verifier_name = str(getattr(verifier, "name", "")).strip()
+        if verifier_name in self.invalidated_verifiers:
+            raise PermissionError(f"verifier is invalidated: {verifier_name}")
         if not getattr(verifier, "trusted", False):
-            raise PermissionError(f"verifier is not trusted: {getattr(verifier, 'name', '')}")
+            raise PermissionError(f"verifier is not trusted: {verifier_name}")
         verifier_class = str(getattr(verifier, "verifier_class", "")).strip()
         if not verifier_class:
             raise ValueError("registered verifier must declare verifier_class")
@@ -200,7 +241,7 @@ class FableRun:
             raise ValueError("verifier returned a result for the wrong session or candidate")
         result = replace(
             raw,
-            verifier=getattr(verifier, "name", raw.verifier),
+            verifier=verifier_name or raw.verifier,
             verifier_class=verifier_class,
             candidate_hash=canonical_hash(candidate.artifact),
             inspected_candidate=True,
@@ -210,6 +251,15 @@ class FableRun:
         result = replace(result, runtime_attestation=self._attestation(result))
         self._record_attested_verification(result)
         return result
+
+    def invalidate_verifier(self, verifier: str, reason: str) -> None:
+        """Revoke a verifier's authority for future finalization decisions."""
+        if not verifier or not verifier.strip() or not reason or not reason.strip():
+            raise ValueError("verifier and reason must be non-empty")
+        with self._lock:
+            self.invalidated_verifiers[verifier.strip()] = reason.strip()
+            self._event("verifier_invalidated", verifier=verifier.strip(),
+                        reason=reason.strip())
 
     def successful_capabilities(self) -> set[str]:
         return {r.capability for r in self.receipts.values() if r.success}
@@ -234,7 +284,7 @@ class FableRun:
     def passed_verifications(self, candidate_id: str) -> list[VerificationResult]:
         return [v for v in self.verifications.values()
                 if v.candidate_id == candidate_id and v.passed and v.trusted
-                and v.inspected_candidate]
+                and v.inspected_candidate and v.verifier not in self.invalidated_verifiers]
 
     def verification_requirements(self, candidate_id: str) -> list[str]:
         """Return missing policy requirements for the exact candidate."""
@@ -267,6 +317,70 @@ class FableRun:
         self.state = RunState.FINALIZED
         self._event("run_finalized", candidate_id=candidate_id)
         return self.candidates[candidate_id]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize a run for round-trip checkpointing."""
+        return {
+            "version": "2.0",
+            "session_id": self.session_id,
+            "task": self.task.to_dict(),
+            "state": self.state.value,
+            "started_at": self.started_at,
+            "receipts": [receipt.to_dict() for receipt in self.receipts.values()],
+            "candidates": [candidate.to_dict() for candidate in self.candidates.values()],
+            "evidence": [item.to_dict() for item in self.evidence.values()],
+            "verifications": [item.to_dict() for item in self.verifications.values()],
+            "events": copy.deepcopy(self.events),
+            "final_candidate_id": self.final_candidate_id,
+            "invalidated_verifiers": dict(self.invalidated_verifiers),
+            # Production deployments should protect this with an external key
+            # store; it is included here so an in-memory checkpoint can be
+            # faithfully restored without silently trusting new signatures.
+            "attestation_secret": self._attestation_secret.hex(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "FableRun":
+        """Restore a run and reject tampered event history or payload hashes."""
+        task_data = dict(data["task"])
+        policy_data = dict(task_data.pop("verification_policy", {}))
+        task_data["constraints"] = tuple(task_data.get("constraints", ()))
+        task_data["definition_of_done"] = tuple(task_data.get("definition_of_done", ()))
+        task_data["required_capabilities"] = tuple(task_data.get("required_capabilities", ()))
+        task_data["required_evidence"] = tuple(task_data.get("required_evidence", ()))
+        task_data["verification_policy"] = VerificationPolicy(**policy_data)
+        run = cls(
+            session_id=data["session_id"],
+            task=TaskSpec(**task_data),
+            state=RunState(data.get("state", RunState.CREATED.value)),
+            started_at=data.get("started_at", utc_now()),
+        )
+        secret = data.get("attestation_secret")
+        if secret:
+            run._attestation_secret = bytes.fromhex(secret)
+        run.receipts = {item["receipt_id"]: ToolReceipt(**item)
+                        for item in data.get("receipts", [])}
+        run.candidates = {
+            item["candidate_id"]: Candidate(
+                **{**item,
+                   "receipt_ids": tuple(item.get("receipt_ids", ())),
+                   "evidence_ids": tuple(item.get("evidence_ids", ()))})
+            for item in data.get("candidates", [])
+        }
+        run.evidence = {item["evidence_id"]: Evidence(**item)
+                        for item in data.get("evidence", [])}
+        run.verifications = {
+            item["verification_id"]: VerificationResult(
+                **{**item,
+                   "reasons": tuple(item.get("reasons", ())),
+                   "evidence_ids": tuple(item.get("evidence_ids", ()))})
+            for item in data.get("verifications", [])
+        }
+        run.events = copy.deepcopy(data.get("events", []))
+        run.final_candidate_id = data.get("final_candidate_id")
+        run.invalidated_verifiers = dict(data.get("invalidated_verifiers", {}))
+        run.validate_event_history()
+        return run
 
     def status(self) -> dict[str, Any]:
         return {

--- a/fable_v2/verifiers.py
+++ b/fable_v2/verifiers.py
@@ -35,6 +35,7 @@ class FunctionVerifier:
     verifier_class: str = "deterministic"
     independent: bool = False
     trusted: bool = True
+    evidence_ids: tuple[str, ...] = ()
 
     def verify(self, candidate: Candidate) -> VerificationResult:
         passed, reasons, score = self.check(candidate)
@@ -46,6 +47,7 @@ class FunctionVerifier:
             passed=bool(passed),
             reasons=tuple(str(reason) for reason in reasons),
             score=score,
+            evidence_ids=self.evidence_ids,
         )
 
 

--- a/fable_v2/verifiers.py
+++ b/fable_v2/verifiers.py
@@ -26,15 +26,18 @@ class FunctionVerifier:
 
     The function returns ``(passed, reasons, score)``.  It is deliberately
     dependency-free so hosts can wrap compilers, tests, schemas, or API calls.
-    Trust is assigned by the application registering the verifier, never by a
-    model-facing result.
+    The default boundary is explicitly ``in_process``. This API prevents a
+    model from forging a result, but it does not isolate arbitrary Python
+    application code; process-attested verifiers require a separate broker.
     """
 
     name: str
     check: Callable[[Candidate], tuple[bool, Iterable[str], float | None]]
     verifier_class: str = "deterministic"
     independent: bool = False
-    trusted: bool = True
+    # This is intentionally not named ``trusted``: in-process registration is
+    # an application convention, not a security boundary.
+    trust_boundary: str = "in_process"
     evidence_ids: tuple[str, ...] = ()
 
     def verify(self, candidate: Candidate) -> VerificationResult:

--- a/fable_v2/verifiers.py
+++ b/fable_v2/verifiers.py
@@ -1,0 +1,62 @@
+"""Composable verifier contracts for Fable V2.
+
+Deterministic verifiers should run before model-based judges.  A verifier may
+be backed by tests, a compiler, a citation checker, a schema validator, or an
+independent model; the runtime only accepts explicit VerificationResult data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Protocol
+
+from .protocol import Candidate, VerificationResult
+
+
+class Verifier(Protocol):
+    name: str
+
+    def verify(self, candidate: Candidate) -> VerificationResult:
+        ...
+
+
+@dataclass(frozen=True)
+class FunctionVerifier:
+    """Adapt a deterministic function into a verifier.
+
+    The function returns ``(passed, reasons, score)``.  It is deliberately
+    dependency-free so hosts can wrap compilers, tests, schemas, or API calls.
+    """
+
+    name: str
+    check: Callable[[Candidate], tuple[bool, Iterable[str], float | None]]
+
+    def verify(self, candidate: Candidate) -> VerificationResult:
+        passed, reasons, score = self.check(candidate)
+        return VerificationResult(
+            verification_id=f"{self.name}:{candidate.candidate_id}",
+            session_id=candidate.session_id,
+            candidate_id=candidate.candidate_id,
+            verifier=self.name,
+            passed=bool(passed),
+            reasons=tuple(str(reason) for reason in reasons),
+            score=score,
+        )
+
+
+@dataclass(frozen=True)
+class CompositeVerifier:
+    """Run a list of verifiers and require every one to pass."""
+
+    verifiers: tuple[Verifier, ...]
+
+    @property
+    def name(self) -> str:
+        return "composite[" + ",".join(v.name for v in self.verifiers) + "]"
+
+    def verify_all(self, candidate: Candidate) -> tuple[VerificationResult, ...]:
+        return tuple(verifier.verify(candidate) for verifier in self.verifiers)
+
+    def passed(self, candidate: Candidate) -> bool:
+        results = self.verify_all(candidate)
+        return bool(results) and all(result.passed for result in results)

--- a/fable_v2/verifiers.py
+++ b/fable_v2/verifiers.py
@@ -22,14 +22,19 @@ class Verifier(Protocol):
 
 @dataclass(frozen=True)
 class FunctionVerifier:
-    """Adapt a deterministic function into a verifier.
+    """Adapt a deterministic function into a registered verifier.
 
     The function returns ``(passed, reasons, score)``.  It is deliberately
     dependency-free so hosts can wrap compilers, tests, schemas, or API calls.
+    Trust is assigned by the application registering the verifier, never by a
+    model-facing result.
     """
 
     name: str
     check: Callable[[Candidate], tuple[bool, Iterable[str], float | None]]
+    verifier_class: str = "deterministic"
+    independent: bool = False
+    trusted: bool = True
 
     def verify(self, candidate: Candidate) -> VerificationResult:
         passed, reasons, score = self.check(candidate)

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -1,0 +1,122 @@
+import unittest
+
+from fable_v2 import (
+    Candidate,
+    Evidence,
+    FunctionVerifier,
+    TaskSpec,
+    ToolReceipt,
+    VerificationResult,
+    get_profile,
+    new_run,
+)
+
+
+class FableV2RuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.task = TaskSpec(
+            task_id="coding-001",
+            objective="Repair the failing feature",
+            definition_of_done=("tests pass",),
+            required_capabilities=("inspect_files", "run_tests"),
+            required_evidence=("test-result",),
+        )
+        self.run = new_run("session-001", self.task)
+        self.inspect = ToolReceipt.from_result(
+            receipt_id="r-inspect", session_id="session-001",
+            capability="inspect_files", tool_name="grep",
+            tool_input={"query": "bug"}, tool_output={"matches": 2}, success=True,
+        )
+        self.tests = ToolReceipt.from_result(
+            receipt_id="r-tests", session_id="session-001",
+            capability="run_tests", tool_name="pytest",
+            tool_input={"target": "tests"}, tool_output={"passed": True}, success=True,
+        )
+        self.run.record_receipt(self.inspect)
+        self.run.record_receipt(self.tests)
+        self.evidence = Evidence(
+            evidence_id="e-tests", session_id="session-001",
+            claim="The regression tests pass", kind="test-result",
+            source="pytest: tests", receipt_id="r-tests", content_hash="abc",
+            verified=True,
+        )
+        self.run.attach_evidence(self.evidence)
+        self.candidate = Candidate(
+            candidate_id="candidate-001", session_id="session-001",
+            approach="minimal patch", artifact={"diff": "..."},
+            receipt_ids=("r-inspect", "r-tests"), evidence_ids=("e-tests",),
+        )
+        self.run.register_candidate(self.candidate)
+
+    def test_task_contract_requires_definition_of_done(self):
+        with self.assertRaises(ValueError):
+            TaskSpec(task_id="x", objective="y")
+
+    def test_receipts_are_hashed_and_recorded(self):
+        self.assertEqual(len(self.run.receipts), 2)
+        self.assertNotEqual(self.inspect.input_hash, self.inspect.output_hash)
+        self.assertEqual(self.run.successful_capabilities(), {"inspect_files", "run_tests"})
+
+    def test_finalization_requires_passing_verification(self):
+        with self.assertRaises(PermissionError):
+            self.run.finalize("candidate-001")
+        self.assertEqual(self.run.state.value, "rejected")
+
+    def test_finalization_requires_every_declared_capability(self):
+        task = TaskSpec(
+            task_id="missing", objective="x", definition_of_done=("done",),
+            required_capabilities=("inspect_files", "search_web"),
+        )
+        run = new_run("session-002", task)
+        run.record_receipt(self.inspect.__class__.from_result(
+            receipt_id="r", session_id="session-002", capability="inspect_files",
+            tool_name="grep", tool_input="x", tool_output="y", success=True,
+        ))
+        candidate = Candidate("c", "session-002", "approach", "artifact", ("r",))
+        run.register_candidate(candidate)
+        run.record_verification(VerificationResult(
+            "v", "session-002", "c", "tests", True,
+        ))
+        with self.assertRaises(PermissionError) as error:
+            run.finalize("c")
+        self.assertIn("search_web", str(error.exception))
+
+    def test_verified_candidate_can_finalize(self):
+        self.run.record_verification(VerificationResult(
+            verification_id="v-001", session_id="session-001",
+            candidate_id="candidate-001", verifier="pytest+review",
+            passed=True, reasons=("tests pass",), score=1.0,
+            evidence_ids=("e-tests",),
+        ))
+        result = self.run.finalize("candidate-001")
+        self.assertEqual(result.candidate_id, "candidate-001")
+        self.assertEqual(self.run.state.value, "finalized")
+
+    def test_failed_tool_cannot_anchor_evidence(self):
+        failed = ToolReceipt.from_result(
+            receipt_id="r-failed", session_id="session-001", capability="run_tests",
+            tool_name="pytest", tool_input="x", tool_output="failure", success=False,
+        )
+        self.run.record_receipt(failed)
+        with self.assertRaises(ValueError):
+            self.run.attach_evidence(Evidence(
+                "e-failed", "session-001", "it passed", "test-result", "pytest",
+                "r-failed", "hash",
+            ))
+
+    def test_verifier_function_is_composable(self):
+        verifier = FunctionVerifier("always-pass", lambda candidate: (True, ["ok"], 1.0))
+        result = verifier.verify(self.candidate)
+        self.assertTrue(result.passed)
+        self.assertEqual(result.verifier, "always-pass")
+
+    def test_host_profiles_are_conservative_and_normalize_aliases(self):
+        profile = get_profile("antigravity")
+        self.assertTrue(profile.supports("run_tests"))
+        self.assertEqual(profile.normalize("run_command"), "execute_command")
+        unknown = get_profile("unknown-host")
+        self.assertFalse(unknown.compatibility_report(["run_tests"])["compatible"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -6,6 +6,7 @@ from fable_v2 import (
     FunctionVerifier,
     TaskSpec,
     ToolReceipt,
+    VerificationPolicy,
     VerificationResult,
     get_profile,
     new_run,
@@ -57,37 +58,53 @@ class FableV2RuntimeTests(unittest.TestCase):
         self.assertNotEqual(self.inspect.input_hash, self.inspect.output_hash)
         self.assertEqual(self.run.successful_capabilities(), {"inspect_files", "run_tests"})
 
-    def test_finalization_requires_passing_verification(self):
+    def test_direct_model_supplied_verification_is_rejected(self):
+        forged = VerificationResult("v", "session-001", "candidate-001", "model", True)
+        with self.assertRaises(PermissionError):
+            self.run.record_verification(forged)
         with self.assertRaises(PermissionError):
             self.run.finalize("candidate-001")
-        self.assertEqual(self.run.state.value, "rejected")
 
     def test_finalization_requires_every_declared_capability(self):
         task = TaskSpec(
             task_id="missing", objective="x", definition_of_done=("done",),
             required_capabilities=("inspect_files", "search_web"),
+            verification_policy=VerificationPolicy(
+                required_verifier_classes=("deterministic",),
+                minimum_passing_verifiers=1,
+                require_independent=False,
+            ),
         )
         run = new_run("session-002", task)
-        run.record_receipt(self.inspect.__class__.from_result(
+        run.record_receipt(ToolReceipt.from_result(
             receipt_id="r", session_id="session-002", capability="inspect_files",
             tool_name="grep", tool_input="x", tool_output="y", success=True,
         ))
         candidate = Candidate("c", "session-002", "approach", "artifact", ("r",))
         run.register_candidate(candidate)
-        run.record_verification(VerificationResult(
-            "v", "session-002", "c", "tests", True,
-        ))
+        run.execute_verifier(FunctionVerifier(
+            "tests", lambda candidate: (True, ("checked",), 1.0)
+        ), "c")
         with self.assertRaises(PermissionError) as error:
             run.finalize("c")
         self.assertIn("search_web", str(error.exception))
 
+    def test_policy_requires_independent_verifier_class(self):
+        self.run.execute_verifier(FunctionVerifier(
+            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0)
+        ), "candidate-001")
+        with self.assertRaises(PermissionError) as error:
+            self.run.finalize("candidate-001")
+        self.assertIn("independent", str(error.exception))
+
     def test_verified_candidate_can_finalize(self):
-        self.run.record_verification(VerificationResult(
-            verification_id="v-001", session_id="session-001",
-            candidate_id="candidate-001", verifier="pytest+review",
-            passed=True, reasons=("tests pass",), score=1.0,
-            evidence_ids=("e-tests",),
-        ))
+        self.run.execute_verifier(FunctionVerifier(
+            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0)
+        ), "candidate-001")
+        self.run.execute_verifier(FunctionVerifier(
+            "independent-review", lambda candidate: (True, ("review passed",), 1.0),
+            verifier_class="independent", independent=True,
+        ), "candidate-001")
         result = self.run.finalize("candidate-001")
         self.assertEqual(result.candidate_id, "candidate-001")
         self.assertEqual(self.run.state.value, "finalized")
@@ -103,6 +120,13 @@ class FableV2RuntimeTests(unittest.TestCase):
                 "e-failed", "session-001", "it passed", "test-result", "pytest",
                 "r-failed", "hash",
             ))
+
+    def test_untrusted_verifier_cannot_finalize(self):
+        verifier = FunctionVerifier(
+            "untrusted", lambda candidate: (True, ("claimed",), 1.0), trusted=False
+        )
+        with self.assertRaises(PermissionError):
+            self.run.execute_verifier(verifier, "candidate-001")
 
     def test_verifier_function_is_composable(self):
         verifier = FunctionVerifier("always-pass", lambda candidate: (True, ["ok"], 1.0))

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -41,7 +41,6 @@ class FableV2RuntimeTests(unittest.TestCase):
             claim="The regression tests pass",
             kind="test-result",
             source="pytest: tests",
-            verified=True,
         )
         self.run.attach_evidence(self.evidence)
         self.candidate = Candidate(
@@ -58,6 +57,7 @@ class FableV2RuntimeTests(unittest.TestCase):
     def test_receipts_are_hashed_and_recorded(self):
         self.assertEqual(len(self.run.receipts), 2)
         self.assertNotEqual(self.inspect.input_hash, self.inspect.output_hash)
+        self.assertTrue(self.evidence.integrity_bound)
         self.assertEqual(self.run.successful_capabilities(), {"inspect_files", "run_tests"})
 
     def test_direct_model_supplied_verification_is_rejected(self):
@@ -85,7 +85,7 @@ class FableV2RuntimeTests(unittest.TestCase):
         run.attach_evidence(Evidence.from_receipt(
             run.receipts["r"],
             evidence_id="e", claim="inspection completed", kind="inspection",
-            source="grep", verified=True,
+            source="grep",
         ))
         candidate = Candidate("c", "session-002", "approach", "artifact", ("r",), ("e",))
         run.register_candidate(candidate)

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -35,10 +35,12 @@ class FableV2RuntimeTests(unittest.TestCase):
         )
         self.run.record_receipt(self.inspect)
         self.run.record_receipt(self.tests)
-        self.evidence = Evidence(
-            evidence_id="e-tests", session_id="session-001",
-            claim="The regression tests pass", kind="test-result",
-            source="pytest: tests", receipt_id="r-tests", content_hash="abc",
+        self.evidence = Evidence.from_receipt(
+            self.tests,
+            evidence_id="e-tests",
+            claim="The regression tests pass",
+            kind="test-result",
+            source="pytest: tests",
             verified=True,
         )
         self.run.attach_evidence(self.evidence)
@@ -80,9 +82,10 @@ class FableV2RuntimeTests(unittest.TestCase):
             receipt_id="r", session_id="session-002", capability="inspect_files",
             tool_name="grep", tool_input="x", tool_output="y", success=True,
         ))
-        run.attach_evidence(Evidence(
-            "e", "session-002", "inspection completed", "inspection", "grep",
-            "r", "hash", verified=True,
+        run.attach_evidence(Evidence.from_receipt(
+            run.receipts["r"],
+            evidence_id="e", claim="inspection completed", kind="inspection",
+            source="grep", verified=True,
         ))
         candidate = Candidate("c", "session-002", "approach", "artifact", ("r",), ("e",))
         run.register_candidate(candidate)
@@ -130,10 +133,18 @@ class FableV2RuntimeTests(unittest.TestCase):
         )
         self.run.record_receipt(failed)
         with self.assertRaises(ValueError):
-            self.run.attach_evidence(Evidence(
-                "e-failed", "session-001", "it passed", "test-result", "pytest",
-                "r-failed", "hash",
-            ))
+            Evidence.from_receipt(
+                failed, evidence_id="e-failed", claim="it passed",
+                kind="test-result", source="pytest",
+            )
+
+    def test_evidence_hash_must_match_actual_content(self):
+        with self.assertRaises(ValueError):
+            Evidence(
+                "e-tampered", "session-001", "claim", "test-result", "pytest",
+                "r-tests", "not-the-output-hash", source_output_hash=self.tests.output_hash,
+                content=self.tests.output,
+            )
 
     def test_untrusted_verifier_cannot_finalize(self):
         verifier = FunctionVerifier(

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -1,8 +1,10 @@
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 
 from fable_v2 import (
     Candidate,
     Evidence,
+    FableRun,
     FunctionVerifier,
     TaskSpec,
     ToolReceipt,
@@ -158,6 +160,118 @@ class FableV2RuntimeTests(unittest.TestCase):
         result = verifier.verify(self.candidate)
         self.assertTrue(result.passed)
         self.assertEqual(result.verifier, "always-pass")
+
+    def test_verifier_cannot_return_a_result_for_another_candidate(self):
+        class WrongCandidateVerifier:
+            name = "wrong-candidate"
+            verifier_class = "deterministic"
+            independent = False
+            trusted = True
+
+            def verify(self, candidate):
+                return VerificationResult(
+                    "wrong", candidate.session_id, "another-candidate", self.name, True,
+                    evidence_ids=("e-tests",),
+                )
+
+        with self.assertRaises(ValueError):
+            self.run.execute_verifier(WrongCandidateVerifier(), "candidate-001")
+
+    def test_verifier_evidence_must_belong_to_candidate(self):
+        candidate = Candidate(
+            "candidate-002", "session-001", "second approach", "other artifact",
+            ("r-inspect",), (),
+        )
+        self.run.register_candidate(candidate)
+        with self.assertRaises(PermissionError):
+            self.run.execute_verifier(FunctionVerifier(
+                "wrong-evidence", lambda candidate: (True, ("checked",), 1.0),
+                evidence_ids=("e-tests",),
+            ), "candidate-002")
+
+    def test_duplicate_or_contradictory_verification_is_rejected(self):
+        verifier = FunctionVerifier(
+            "single-use", lambda candidate: (True, ("checked",), 1.0),
+            evidence_ids=("e-tests",),
+        )
+        self.run.execute_verifier(verifier, "candidate-001")
+        with self.assertRaises(ValueError):
+            self.run.execute_verifier(verifier, "candidate-001")
+        with self.assertRaises(ValueError):
+            self.run.execute_verifier(FunctionVerifier(
+                "single-use", lambda candidate: (False, ("contradiction",), 0.0),
+                evidence_ids=("e-tests",),
+            ), "candidate-001")
+
+    def test_finalization_rechecks_verifier_validity(self):
+        self.run.execute_verifier(FunctionVerifier(
+            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0),
+            evidence_ids=("e-tests",),
+        ), "candidate-001")
+        self.run.execute_verifier(FunctionVerifier(
+            "independent-review", lambda candidate: (True, ("review passed",), 1.0),
+            verifier_class="independent", independent=True, evidence_ids=("e-tests",),
+        ), "candidate-001")
+        self.run.invalidate_verifier("independent-review", "calibration drift")
+        with self.assertRaises(PermissionError) as error:
+            self.run.finalize("candidate-001")
+        self.assertIn("independent", str(error.exception))
+
+    def test_malformed_or_reversed_timestamps_are_rejected(self):
+        with self.assertRaises(ValueError):
+            ToolReceipt.from_result(
+                receipt_id="bad-time", session_id="session-001", capability="x",
+                tool_name="x", tool_input="x", tool_output="x", success=True,
+                started_at="not-a-time", finished_at="not-a-time",
+            )
+        with self.assertRaises(ValueError):
+            ToolReceipt.from_result(
+                receipt_id="reversed", session_id="session-001", capability="x",
+                tool_name="x", tool_input="x", tool_output="x", success=True,
+                started_at="2026-08-28T12:00:00+00:00",
+                finished_at="2026-08-28T11:00:00+00:00",
+            )
+
+    def test_mutable_payloads_are_snapshotted(self):
+        output = {"passed": True}
+        metadata = {"host": {"name": "test"}}
+        receipt = ToolReceipt.from_result(
+            receipt_id="snapshot", session_id="session-001", capability="x",
+            tool_name="x", tool_input="x", tool_output=output, success=True,
+            metadata=metadata,
+        )
+        output["passed"] = False
+        metadata["host"]["name"] = "mutated"
+        self.assertTrue(receipt.output["passed"])
+        self.assertEqual(receipt.metadata["host"]["name"], "test")
+
+        artifact = {"items": [1]}
+        candidate = Candidate("snapshot-candidate", "session-001", "approach", artifact)
+        self.run.register_candidate(candidate)
+        artifact["items"].append(2)
+        self.assertEqual(self.run.candidates["snapshot-candidate"].artifact, {"items": [1]})
+
+    def test_run_serialization_round_trip(self):
+        restored = FableRun.from_dict(self.run.to_dict())
+        self.assertEqual(restored.status(), self.run.status())
+        restored.validate_event_history()
+        self.assertEqual(restored.evidence["e-tests"].content_hash, self.evidence.content_hash)
+
+    def test_parallel_candidate_registration_is_safe(self):
+        candidates = [
+            Candidate(f"parallel-{i}", "session-001", "parallel approach", {"i": i})
+            for i in range(32)
+        ]
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(self.run.register_candidate, candidates))
+        self.assertEqual(len(self.run.candidates), 33)
+        self.run.validate_event_history()
+
+    def test_tampered_event_history_is_rejected_on_restore(self):
+        payload = self.run.to_dict()
+        payload["events"][0]["type"] = "tampered"
+        with self.assertRaises(ValueError):
+            FableRun.from_dict(payload)
 
     def test_host_profiles_are_expected_until_probed(self):
         profile = get_profile("antigravity")

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -148,12 +148,47 @@ class FableV2RuntimeTests(unittest.TestCase):
                 content=self.tests.output,
             )
 
-    def test_untrusted_verifier_cannot_finalize(self):
+    def test_in_process_verifier_cannot_claim_process_attestation(self):
         verifier = FunctionVerifier(
-            "untrusted", lambda candidate: (True, ("claimed",), 1.0), trusted=False
+            "forged-boundary", lambda candidate: (True, ("claimed",), 1.0),
+            trust_boundary="process_attested",
         )
         with self.assertRaises(PermissionError):
             self.run.execute_verifier(verifier, "candidate-001")
+
+    def test_process_attested_policy_rejects_in_process_results(self):
+        task = TaskSpec(
+            task_id="isolated", objective="x", definition_of_done=("done",),
+            required_capabilities=("inspect_files",),
+            verification_policy=VerificationPolicy(
+                required_verifier_classes=("deterministic",),
+                minimum_passing_verifiers=1,
+                require_independent=False,
+                minimum_trust_boundary="process_attested",
+            ),
+        )
+        run = new_run("session-isolated", task)
+        receipt = ToolReceipt.from_result(
+            receipt_id="r-isolated", session_id="session-isolated",
+            capability="inspect_files", tool_name="grep", tool_input="x",
+            tool_output="y", success=True,
+        )
+        run.record_receipt(receipt)
+        evidence = Evidence.from_receipt(
+            receipt, evidence_id="e-isolated", claim="inspected", kind="inspection",
+            source="grep",
+        )
+        run.attach_evidence(evidence)
+        run.register_candidate(Candidate(
+            "c-isolated", "session-isolated", "approach", "artifact",
+            ("r-isolated",), ("e-isolated",),
+        ))
+        run.execute_verifier(FunctionVerifier(
+            "local", lambda candidate: (True, ("checked",), 1.0),
+            evidence_ids=("e-isolated",),
+        ), "c-isolated")
+        with self.assertRaises(PermissionError):
+            run.finalize("c-isolated")
 
     def test_verifier_function_is_composable(self):
         verifier = FunctionVerifier("always-pass", lambda candidate: (True, ["ok"], 1.0))
@@ -166,7 +201,7 @@ class FableV2RuntimeTests(unittest.TestCase):
             name = "wrong-candidate"
             verifier_class = "deterministic"
             independent = False
-            trusted = True
+            trust_boundary = "in_process"
 
             def verify(self, candidate):
                 return VerificationResult(

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -159,10 +159,16 @@ class FableV2RuntimeTests(unittest.TestCase):
         self.assertTrue(result.passed)
         self.assertEqual(result.verifier, "always-pass")
 
-    def test_host_profiles_are_conservative_and_normalize_aliases(self):
+    def test_host_profiles_are_expected_until_probed(self):
         profile = get_profile("antigravity")
+        self.assertFalse(profile.is_attested)
         self.assertTrue(profile.supports("run_tests"))
+        self.assertFalse(profile.supports("run_tests", authoritative=True))
         self.assertEqual(profile.normalize("run_command"), "execute_command")
+        self.assertFalse(profile.compatibility_report(["run_tests"])["compatible"])
+        attested = profile.attest(["run_tests"])
+        self.assertTrue(attested.is_attested)
+        self.assertTrue(attested.compatibility_report(["run_tests"])["compatible"])
         unknown = get_profile("unknown-host")
         self.assertFalse(unknown.compatibility_report(["run_tests"])["compatible"])
 

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -80,18 +80,31 @@ class FableV2RuntimeTests(unittest.TestCase):
             receipt_id="r", session_id="session-002", capability="inspect_files",
             tool_name="grep", tool_input="x", tool_output="y", success=True,
         ))
-        candidate = Candidate("c", "session-002", "approach", "artifact", ("r",))
+        run.attach_evidence(Evidence(
+            "e", "session-002", "inspection completed", "inspection", "grep",
+            "r", "hash", verified=True,
+        ))
+        candidate = Candidate("c", "session-002", "approach", "artifact", ("r",), ("e",))
         run.register_candidate(candidate)
         run.execute_verifier(FunctionVerifier(
-            "tests", lambda candidate: (True, ("checked",), 1.0)
+            "tests", lambda candidate: (True, ("checked",), 1.0), evidence_ids=("e",)
         ), "c")
         with self.assertRaises(PermissionError) as error:
             run.finalize("c")
         self.assertIn("search_web", str(error.exception))
 
+    def test_deterministic_verifier_must_run_before_independent(self):
+        with self.assertRaises(PermissionError) as error:
+            self.run.execute_verifier(FunctionVerifier(
+                "independent-first", lambda candidate: (True, ("reviewed",), 1.0),
+                verifier_class="independent", independent=True, evidence_ids=("e-tests",),
+            ), "candidate-001")
+        self.assertIn("after passing deterministic", str(error.exception))
+
     def test_policy_requires_independent_verifier_class(self):
         self.run.execute_verifier(FunctionVerifier(
-            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0)
+            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0),
+            evidence_ids=("e-tests",),
         ), "candidate-001")
         with self.assertRaises(PermissionError) as error:
             self.run.finalize("candidate-001")
@@ -99,11 +112,12 @@ class FableV2RuntimeTests(unittest.TestCase):
 
     def test_verified_candidate_can_finalize(self):
         self.run.execute_verifier(FunctionVerifier(
-            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0)
+            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0),
+            evidence_ids=("e-tests",),
         ), "candidate-001")
         self.run.execute_verifier(FunctionVerifier(
             "independent-review", lambda candidate: (True, ("review passed",), 1.0),
-            verifier_class="independent", independent=True,
+            verifier_class="independent", independent=True, evidence_ids=("e-tests",),
         ), "candidate-001")
         result = self.run.finalize("candidate-001")
         self.assertEqual(result.candidate_id, "candidate-001")


### PR DESCRIPTION
## Summary

This PR starts the Fable V2 transition from a host-specific cognitive/session protocol to a portable, evidence-gated runtime.

### Included
- Added host-neutral protocol objects for task contracts, tool receipts, evidence, candidates, and verification results.
- Added an evidence-gated run state machine that rejects incomplete finalization.
- Added composable deterministic verifier contracts.
- Added conservative host capability profiles and tool alias normalization for Antigravity, Claude Code, Codex, Cursor, Grok Build, and Zapia.
- Added an architecture RFC describing the portable core, adapters, enforcement model, benchmark plan, and 10x/50x targets as hypotheses rather than guarantees.
- Added README documentation and 8 unit tests for the V2 foundation.

### Validation
- `python3 -m unittest discover -s tests -v`
- 8 tests passed.

### Follow-up work
- Implement live MCP/CLI/HTTP adapters.
- Add candidate fleet orchestration and adaptive budget allocation.
- Add real test, citation, schema, and sandbox verifiers.
- Add held-out cross-host benchmark harness before making uplift claims.

The runtime intentionally does not claim that a prompt or MCP call proves correctness; host-produced receipts and independent verification are required.