### PR TITLE
fix: fully attest and restore verification verdicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,3 +544,22 @@ criteria.
 The 10x/50x uplift figures are ambitious hypotheses for measured task classes,
 not universal guarantees. Results must be established on held-out benchmarks
 with success, error reduction, cost, latency, and verifier-quality metrics.
+
+### V1 versus V2 entry points
+
+The existing `fable-engine` command and the repository's legacy MCP schema
+launch **V1** (`fable_engine.server`). `fable-v1` is an explicit alias for the
+same legacy server; existing installers remain V1-compatible.
+
+The portable V2 runtime lives in `fable_v2/`. Its execution boundary is
+launched with `fable-v2-broker --workspace <path>`. The broker is a separate
+process that owns allowlisted command execution and workspace writes; hosts
+must route V2 execution through it rather than granting models direct file
+access. `fable-v2-broker` is the V2 broker entry point, not a drop-in alias for
+the legacy `fable_session` MCP server.
+
+The V2 migration path is documented in
+[`docs/fable-v1-v2-migration.md`](docs/fable-v1-v2-migration.md) and
+`docs/fable-v2-architecture.md`: installers that still register `fable-engine`
+deliberately run V1 until a host adapter is configured for the V2 runtime and
+broker.

--- a/docs/fable-v1-v2-migration.md
+++ b/docs/fable-v1-v2-migration.md
@@ -24,7 +24,9 @@ fable-v2-broker --workspace /path/to/workspace
 Hosts should communicate with the broker over its JSON-lines stdin/stdout
 protocol and route command execution and file writes through it. The broker
 allowlists executables, constrains paths to the workspace, keeps writes locked
-until administrative authorization, and runs commands without a shell.
+until administrative authorization, blocks general interpreters while writes
+are locked, and runs commands without a shell. This prevents the common
+`python -c "open(...)"` bypass at the broker policy layer.
 
 This is a process/policy boundary, not a complete operating-system sandbox.
 For hostile workloads, run the broker inside a container or equivalent OS

--- a/docs/fable-v1-v2-migration.md
+++ b/docs/fable-v1-v2-migration.md
@@ -27,6 +27,12 @@ The CLI loads write authorization from an administrator-controlled
 hex digest of the administrative token; it is never returned by the broker's
 probe response and must not be added to a model-facing tool schema.
 
+Unlocking is performed over a separate inherited POSIX admin file descriptor,
+passed with `--admin-fd`; the model-facing JSON-lines stdin channel has no
+unlock action and no token field. A host adapter must keep the admin pipe and
+token outside the model's tool surface. Windows adapters should use an
+equivalent protected named-pipe/control-handle implementation.
+
 Hosts should communicate with the broker over its JSON-lines stdin/stdout
 protocol and route command execution and file writes through it. The broker
 allowlists executables, constrains paths to the workspace, keeps writes locked

--- a/docs/fable-v1-v2-migration.md
+++ b/docs/fable-v1-v2-migration.md
@@ -1,0 +1,42 @@
+# Fable V1 to V2 entry points
+
+## Current entry points
+
+| Entry point | Version | Purpose |
+|---|---|---|
+| `fable-engine` | V1 (legacy) | Existing `fable_session` MCP server from `fable_engine.server` |
+| `fable-v1` | V1 (legacy alias) | Explicit alias for `fable-engine` |
+| `fable-v2-broker` | V2 | Process execution broker from `fable_v2.execution_broker` |
+
+The existing `install.sh` and `install.ps1` scripts intentionally install and
+register the V1 MCP server for backward compatibility. They now print that
+fact explicitly. Installing the V2 Python package adds the `fable-v2-broker`
+entry point; it does not silently replace the old MCP server.
+
+## V2 execution boundary
+
+Start the broker with a workspace it owns:
+
+```bash
+fable-v2-broker --workspace /path/to/workspace
+```
+
+Hosts should communicate with the broker over its JSON-lines stdin/stdout
+protocol and route command execution and file writes through it. The broker
+allowlists executables, constrains paths to the workspace, keeps writes locked
+until administrative authorization, and runs commands without a shell.
+
+This is a process/policy boundary, not a complete operating-system sandbox.
+For hostile workloads, run the broker inside a container or equivalent OS
+sandbox with least-privilege filesystem and network permissions.
+
+## Migration order
+
+1. Keep the V1 MCP server enabled while the host adapter is being tested.
+2. Install the package and start `fable-v2-broker` in a dedicated workspace.
+3. Probe the host and broker capabilities; treat expected profiles as
+   non-authoritative until attested.
+4. Route V2 tool calls through the broker and create candidate-scoped receipts.
+5. Enable V2 finalization only after verifier and broker conformance tests pass.
+6. Remove or disable the V1 MCP registration only after the host adapter has
+   been validated on the target environment.

--- a/docs/fable-v1-v2-migration.md
+++ b/docs/fable-v1-v2-migration.md
@@ -21,6 +21,12 @@ Start the broker with a workspace it owns:
 fable-v2-broker --workspace /path/to/workspace
 ```
 
+The CLI loads write authorization from an administrator-controlled
+`FABLE_BROKER_WRITE_TOKEN_DIGEST` environment variable or
+`FABLE_BROKER_WRITE_TOKEN_DIGEST_FILE` protected file. The value is a SHA-256
+hex digest of the administrative token; it is never returned by the broker's
+probe response and must not be added to a model-facing tool schema.
+
 Hosts should communicate with the broker over its JSON-lines stdin/stdout
 protocol and route command execution and file writes through it. The broker
 allowlists executables, constrains paths to the workspace, keeps writes locked

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -83,8 +83,13 @@ writable layer or remount after authorization.
 Hostile workloads still require container/VM isolation and least-privilege OS
 controls. The broker resolves each allowlisted executable to a trusted absolute path at
 startup and rejects requests whose resolved path differs; a matching basename
-is not sufficient. The broker is covered by child-process, executable-path,
-allowlist, path-containment, and locked-write tests.
+is not sufficient. Command stdout/stderr are drained concurrently into bounded
+buffers; exceeding `max_output_bytes` terminates the process (and its POSIX
+process group) instead of truncating after unbounded `subprocess.run()` capture.
+The broker implements every advertised protocol capability, including bounded
+`inspect_files` and the `probe_capabilities` alias. It is covered by
+child-process, executable-path, output-limit, capability, allowlist,
+path-containment, and locked-write tests.
 
 The checked-in `HOST_PROFILES` are explicitly **expected capability
 profiles**, not attestations. They are useful defaults for planning and

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -62,6 +62,20 @@ Supported integrations should be implemented as thin adapters, not forks of
 the cognitive engine. MCP is the preferred tool binding, but a CLI or HTTP
 adapter is required for hosts that do not expose MCP.
 
+## Execution boundary
+
+`fable_v2.execution_broker` provides the first concrete execution boundary for
+V2. `fable-v2-broker` runs as a separate process, allowlists executables,
+executes without a shell, constrains working directories and file writes to a
+configured workspace, and keeps writes locked until administrative
+authorization. Hosts must route V2 command execution and writes through this
+broker instead of giving the model direct filesystem access.
+
+This is a process and policy boundary, not a complete operating-system sandbox.
+Hostile workloads still require container/VM isolation and least-privilege OS
+controls. The broker is covered by child-process, allowlist, path-containment,
+and locked-write tests.
+
 The checked-in `HOST_PROFILES` are explicitly **expected capability
 profiles**, not attestations. They are useful defaults for planning and
 documentation, but they are not runtime-authoritative. A live adapter must

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -131,14 +131,20 @@ capabilities and evidence kinds have been satisfied and its
 Verification is policy-enforced, not a free-form boolean. A result supplied
 from a model-facing call is rejected. The in-process foundation API runs a
 verifier against the exact candidate artifact and runtime-attests that
-invocation with the candidate hash. This blocks forged model results, but it
-is **not** a security boundary against arbitrary Python application code: an
-in-process caller can still construct or alter verifier code. The task policy
-can require verifier classes such as `deterministic`, `machine-check`, and
-`independent`, a minimum number of passing verifiers, and a minimum trust
-boundary. The current foundation supports `in_process`; production-grade
-`process_attested` results must come from a separate broker with process
-isolation and signed/ authenticated registrations.
+invocation with the candidate hash. The attestation also includes a candidate
+dependency-graph commitment: the candidate state and authenticated object
+hashes for every referenced `ToolReceipt` and `Evidence`, including receipt
+capability/success fields and evidence provenance. Restore recomputes this
+commitment before accepting a stored verdict, so changing receipt/evidence
+references or their serialized state invalidates the verdict. This blocks
+forged model results, but it is **not** a security boundary against arbitrary
+Python application code: an in-process caller can still construct or alter
+verifier code. The task policy can require verifier classes such as
+`deterministic`, `machine-check`, and `independent`, a minimum number of
+passing verifiers, and a minimum trust boundary. The current foundation
+supports `in_process`; production-grade `process_attested` results must come
+from a separate broker with process isolation and signed/ authenticated
+registrations.
 
 Semantic trust in a model judge remains an explicit deployment decision and
 should be backed by calibration and hidden tests.

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -218,7 +218,9 @@ receipt ledger into a false correctness oracle:
 - verifier invalidation after a prior pass;
 - malformed and reversed timestamps;
 - mutable metadata and artifact snapshotting;
+- candidate dependency-graph and receipt/evidence state tampering;
 - run serialization round-trips;
+- bounded broker output and capability dispatch;
 - concurrent candidate registration;
 - expected versus probed capability aliases;
 - verifier policy enforcement; and

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -72,7 +72,9 @@ authorization. General interpreters and shell entry points are also blocked
 while writes are locked, because `shell=False` does not stop a command such as
 `python -c "open(...)"` from writing files. Hosts must route V2 command
 execution and writes through this broker instead of giving the model direct
-filesystem access.
+filesystem access. The administrative unlock is accepted only on a separate
+inherited control handle (`--admin-fd` on POSIX), never through the model's
+JSON-lines request channel.
 
 This is a process and policy boundary, not a complete operating-system sandbox.
 For a hardened deployment, the broker process must run with an OS-enforced

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -79,8 +79,10 @@ For a hardened deployment, the broker process must run with an OS-enforced
 read-only workspace before authorization, then receive a separately controlled
 writable layer or remount after authorization.
 Hostile workloads still require container/VM isolation and least-privilege OS
-controls. The broker is covered by child-process, allowlist, path-containment,
-and locked-write tests.
+controls. The broker resolves each allowlisted executable to a trusted absolute path at
+startup and rejects requests whose resolved path differs; a matching basename
+is not sufficient. The broker is covered by child-process, executable-path,
+allowlist, path-containment, and locked-write tests.
 
 The checked-in `HOST_PROFILES` are explicitly **expected capability
 profiles**, not attestations. They are useful defaults for planning and

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -194,10 +194,14 @@ judges.
 ## Checkpoint trust boundary
 
 `FableRun.to_dict()` and `from_dict()` provide serialization and restoration,
-not a generally tamper-proof audit artifact. The event hash chain detects
-edited or reordered events, but the experimental checkpoint currently stores
-the HMAC attestation secret in the same payload. Someone who can rewrite that
-payload could rewrite state and recompute the in-process HMAC.
+not a generally tamper-proof audit artifact. Each verification attestation now
+covers a canonical hash of the complete immutable `VerificationResult` (apart
+from the attestation itself), and restoration revalidates every restored
+verdict against its candidate, evidence, and attestation before it can affect
+finalization. The event hash chain detects edited or reordered events, but the
+experimental checkpoint currently stores the HMAC attestation secret in the
+same payload. Someone who can rewrite that payload could rewrite state and
+recompute the in-process HMAC.
 
 Production checkpoints must keep signing keys outside the serialized state,
 ideally in an external key store or isolated broker. The broker should sign

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -68,10 +68,16 @@ adapter is required for hosts that do not expose MCP.
 V2. `fable-v2-broker` runs as a separate process, allowlists executables,
 executes without a shell, constrains working directories and file writes to a
 configured workspace, and keeps writes locked until administrative
-authorization. Hosts must route V2 command execution and writes through this
-broker instead of giving the model direct filesystem access.
+authorization. General interpreters and shell entry points are also blocked
+while writes are locked, because `shell=False` does not stop a command such as
+`python -c "open(...)"` from writing files. Hosts must route V2 command
+execution and writes through this broker instead of giving the model direct
+filesystem access.
 
 This is a process and policy boundary, not a complete operating-system sandbox.
+For a hardened deployment, the broker process must run with an OS-enforced
+read-only workspace before authorization, then receive a separately controlled
+writable layer or remount after authorization.
 Hostile workloads still require container/VM isolation and least-privilege OS
 controls. The broker is covered by child-process, allowlist, path-containment,
 and locked-write tests.

--- a/docs/fable-v2-architecture.md
+++ b/docs/fable-v2-architecture.md
@@ -125,8 +125,10 @@ classes, but it does not pretend that an arbitrary `VerificationResult` proves
 anything.
 
 The runtime enforces required capabilities and verifier classes for the task,
-not every available tool. Requiring irrelevant tools would create waste and
-tool theatre.
+not every available tool. Required capabilities are resolved exclusively from
+the selected candidate's referenced successful receipts; work performed only
+by another candidate cannot satisfy the policy. Requiring irrelevant tools
+would create waste and tool theatre.
 
 ## Runtime objects
 

--- a/fable_v2/__init__.py
+++ b/fable_v2/__init__.py
@@ -1,6 +1,7 @@
 """Experimental portable Fable V2 runtime."""
 
 from .adapters import HOST_PROFILES, HostCapabilities, get_profile
+from .execution_broker import BrokerPolicy, ExecutionBroker
 from .protocol import (
     Candidate,
     Evidence,
@@ -13,7 +14,7 @@ from .runtime import FableRun, RunState, new_run
 from .verifiers import CompositeVerifier, FunctionVerifier
 
 __all__ = [
-    "Candidate", "CompositeVerifier", "Evidence", "FableRun",
+    "BrokerPolicy", "Candidate", "CompositeVerifier", "Evidence", "ExecutionBroker", "FableRun",
     "FunctionVerifier", "HOST_PROFILES", "HostCapabilities", "RunState",
     "TaskSpec", "ToolReceipt", "VerificationPolicy", "VerificationResult",
     "get_profile", "new_run",

--- a/fable_v2/execution_broker.py
+++ b/fable_v2/execution_broker.py
@@ -48,7 +48,17 @@ class BrokerPolicy:
 
 
 class ExecutionBroker:
-    """Allowlisted command and write broker intended to run in a child process."""
+    """Allowlisted command and write broker intended to run in a child process.
+
+    General interpreters and shell entry points are blocked while writes are
+    locked. ``shell=False`` alone is not a filesystem sandbox: an invocation
+    such as ``python -c`` can still write files directly.
+    """
+
+    READ_LOCKED_INTERPRETERS = frozenset({
+        "bash", "cmd", "node", "perl", "php", "pypy", "powershell",
+        "pwsh", "python", "pytest", "ruby", "sh", "zsh",
+    })
 
     def __init__(self, policy: BrokerPolicy):
         self.policy = policy
@@ -64,6 +74,7 @@ class ExecutionBroker:
             "capabilities": ["execute_command", "inspect_files", "probe_capabilities"],
             "available_executables": available,
             "writes_enabled": self._writes_unlocked,
+            "read_locked_interpreters": sorted(self.READ_LOCKED_INTERPRETERS),
             "workspace": str(self.policy.workspace),
         }
 
@@ -120,8 +131,17 @@ class ExecutionBroker:
         if not argv or any(not isinstance(item, str) or not item for item in argv):
             raise ValueError("command must be a non-empty sequence of strings")
         executable = Path(argv[0]).name
+        executable_key = Path(executable).stem.lower()
+        is_interpreter = (
+            executable_key in self.READ_LOCKED_INTERPRETERS
+            or executable_key.startswith("python")
+        )
         if executable not in self.policy.allowed_executables:
             raise PermissionError(f"executable is not allowlisted: {executable}")
+        if is_interpreter and not self._writes_unlocked:
+            raise PermissionError(
+                "general interpreters and shells are blocked while workspace writes are locked"
+            )
         if timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be positive")
         directory = self.policy.workspace if cwd is None else self._safe_path(cwd)

--- a/fable_v2/execution_broker.py
+++ b/fable_v2/execution_broker.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 from typing import Any, Iterable
 
 
@@ -100,7 +101,8 @@ class ExecutionBroker:
             raise PermissionError("path escapes the broker workspace") from exc
         return candidate
 
-    def _authorize_write(self, token: str | None) -> None:
+    def unlock_writes(self, token: str) -> None:
+        """Unlock writes through an administrator-only control channel."""
         if self._writes_unlocked:
             return
         digest = self.policy.write_token_digest
@@ -111,8 +113,12 @@ class ExecutionBroker:
             raise PermissionError("invalid write authorization")
         self._writes_unlocked = True
 
-    def write_file(self, relative_path: str, content: str, token: str | None = None) -> dict[str, Any]:
-        self._authorize_write(token)
+    def _authorize_write(self) -> None:
+        if not self._writes_unlocked:
+            raise PermissionError("workspace writes are locked")
+
+    def write_file(self, relative_path: str, content: str) -> dict[str, Any]:
+        self._authorize_write()
         if not isinstance(content, str):
             raise ValueError("file content must be text")
         target = self._safe_path(relative_path)
@@ -220,13 +226,31 @@ class ExecutionBroker:
                 timeout_seconds=float(request.get("timeout_seconds", 120.0)),
             )
         if action == "write_file":
-            # The write token is an administrative input and must never be
-            # exposed through a model-facing tool schema.
-            return self.write_file(request.get("path", ""), request.get("content", ""), request.get("token"))
+            # No authorization token is accepted on the model JSON channel.
+            return self.write_file(request.get("path", ""), request.get("content", ""))
         raise ValueError(f"unsupported broker action: {action}")
 
 
-def serve(broker: ExecutionBroker) -> None:
+def _serve_admin_fd(broker: ExecutionBroker, fd: int) -> None:
+    """Consume admin commands from an inherited, non-model file descriptor."""
+    with os.fdopen(os.dup(fd), "r", encoding="utf-8") as channel:
+        for line in channel:
+            if not line.strip():
+                continue
+            try:
+                request = json.loads(line)
+                if request.get("action") != "unlock_writes":
+                    raise ValueError("unsupported admin action")
+                broker.unlock_writes(request.get("token", ""))
+            except Exception as exc:
+                print(f"admin control error: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+
+def serve(broker: ExecutionBroker, admin_fd: int | None = None) -> None:
+    if admin_fd is not None:
+        if os.name == "nt":
+            raise ValueError("--admin-fd currently requires a POSIX inherited pipe")
+        threading.Thread(target=_serve_admin_fd, args=(broker, admin_fd), daemon=True).start()
     for line in sys.stdin:
         if not line.strip():
             continue
@@ -257,6 +281,10 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Fable V2 execution broker")
     parser.add_argument("--workspace", required=True, type=Path)
     parser.add_argument("--allow-executable", action="append", default=[])
+    parser.add_argument(
+        "--admin-fd", type=int,
+        help="POSIX inherited one-way admin control FD; never expose to a model",
+    )
     args = parser.parse_args(argv)
     allowed = tuple(args.allow_executable) or BrokerPolicy.allowed_executables
     policy = BrokerPolicy(
@@ -264,7 +292,7 @@ def main(argv: list[str] | None = None) -> int:
         allowed_executables=allowed,
         write_token_digest=_load_write_token_digest(),
     )
-    serve(ExecutionBroker(policy))
+    serve(ExecutionBroker(policy), admin_fd=args.admin_fd)
     return 0
 
 

--- a/fable_v2/execution_broker.py
+++ b/fable_v2/execution_broker.py
@@ -1,0 +1,211 @@
+"""Process-isolated execution boundary for Fable V2.
+
+The broker is the only component in this foundation that should be granted
+workspace write permission. It exposes a small JSON-lines protocol so hosts
+can launch it as a child process and keep model-facing tools away from direct
+filesystem writes. This is a policy boundary, not a complete OS sandbox;
+production deployments should add containers, OS MAC, seccomp/job objects,
+or an equivalent hardened isolation layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import argparse
+import hashlib
+import hmac
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class BrokerPolicy:
+    workspace: Path
+    allowed_executables: tuple[str, ...] = ("python", "python3", "pytest")
+    max_output_bytes: int = 1_000_000
+    write_token_digest: str | None = None
+
+    def __post_init__(self) -> None:
+        workspace = self.workspace.expanduser().resolve()
+        if not workspace.exists() or not workspace.is_dir():
+            raise ValueError("workspace must be an existing directory")
+        if self.max_output_bytes < 1:
+            raise ValueError("max_output_bytes must be positive")
+        if not self.allowed_executables:
+            raise ValueError("at least one executable must be allowlisted")
+        object.__setattr__(self, "workspace", workspace)
+        object.__setattr__(
+            self,
+            "allowed_executables",
+            tuple(Path(item).name for item in self.allowed_executables),
+        )
+
+
+class ExecutionBroker:
+    """Allowlisted command and write broker intended to run in a child process."""
+
+    def __init__(self, policy: BrokerPolicy):
+        self.policy = policy
+        self._writes_unlocked = False
+
+    def probe(self) -> dict[str, Any]:
+        available = [
+            executable for executable in self.policy.allowed_executables
+            if shutil.which(executable)
+        ]
+        return {
+            "host": "fable-execution-broker",
+            "capabilities": ["execute_command", "inspect_files", "probe_capabilities"],
+            "available_executables": available,
+            "writes_enabled": self._writes_unlocked,
+            "workspace": str(self.policy.workspace),
+        }
+
+    def _safe_path(self, relative_path: str) -> Path:
+        if not isinstance(relative_path, str) or not relative_path.strip():
+            raise ValueError("path must be a non-empty relative path")
+        candidate = (self.policy.workspace / relative_path).resolve()
+        try:
+            candidate.relative_to(self.policy.workspace)
+        except ValueError as exc:
+            raise PermissionError("path escapes the broker workspace") from exc
+        return candidate
+
+    def _authorize_write(self, token: str | None) -> None:
+        if self._writes_unlocked:
+            return
+        digest = self.policy.write_token_digest
+        if not digest or not token:
+            raise PermissionError("workspace writes are locked")
+        supplied = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        if not hmac.compare_digest(supplied, digest):
+            raise PermissionError("invalid write authorization")
+        self._writes_unlocked = True
+
+    def write_file(self, relative_path: str, content: str, token: str | None = None) -> dict[str, Any]:
+        self._authorize_write(token)
+        if not isinstance(content, str):
+            raise ValueError("file content must be text")
+        target = self._safe_path(relative_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(prefix=".fable-", dir=str(target.parent), text=True)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, target)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+        return {
+            "path": str(target.relative_to(self.policy.workspace)),
+            "content_hash": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            "writes_enabled": True,
+        }
+
+    def execute_command(
+        self,
+        command: Iterable[str],
+        cwd: str | None = None,
+        timeout_seconds: float = 120.0,
+    ) -> dict[str, Any]:
+        argv = tuple(command)
+        if not argv or any(not isinstance(item, str) or not item for item in argv):
+            raise ValueError("command must be a non-empty sequence of strings")
+        executable = Path(argv[0]).name
+        if executable not in self.policy.allowed_executables:
+            raise PermissionError(f"executable is not allowlisted: {executable}")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        directory = self.policy.workspace if cwd is None else self._safe_path(cwd)
+        if not directory.is_dir():
+            raise ValueError("cwd must be a directory inside the workspace")
+        env = {"PATH": os.environ.get("PATH", ""), "PYTHONUNBUFFERED": "1"}
+        try:
+            completed = subprocess.run(
+                argv,
+                cwd=directory,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                shell=False,
+                timeout=timeout_seconds,
+                check=False,
+            )
+            stdout = completed.stdout
+            stderr = completed.stderr
+            timed_out = False
+            exit_code = completed.returncode
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            timed_out = True
+            exit_code = None
+
+        def truncate(value: str) -> str:
+            if len(value.encode("utf-8")) <= self.policy.max_output_bytes:
+                return value
+            encoded = value.encode("utf-8")[: self.policy.max_output_bytes]
+            return encoded.decode("utf-8", errors="ignore") + "\n[truncated]"
+
+        return {
+            "command": list(argv),
+            "cwd": str(directory.relative_to(self.policy.workspace)),
+            "exit_code": exit_code,
+            "timed_out": timed_out,
+            "stdout": truncate(stdout),
+            "stderr": truncate(stderr),
+            "success": exit_code == 0 and not timed_out,
+        }
+
+    def handle(self, request: dict[str, Any]) -> dict[str, Any]:
+        action = request.get("action")
+        if action == "probe":
+            return self.probe()
+        if action == "execute_command":
+            return self.execute_command(
+                request.get("command", ()),
+                cwd=request.get("cwd"),
+                timeout_seconds=float(request.get("timeout_seconds", 120.0)),
+            )
+        if action == "write_file":
+            # The write token is an administrative input and must never be
+            # exposed through a model-facing tool schema.
+            return self.write_file(request.get("path", ""), request.get("content", ""), request.get("token"))
+        raise ValueError(f"unsupported broker action: {action}")
+
+
+def serve(broker: ExecutionBroker) -> None:
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        try:
+            response = {"ok": True, "result": broker.handle(json.loads(line))}
+        except Exception as exc:  # protocol boundary: never crash the broker loop
+            response = {"ok": False, "error": type(exc).__name__, "message": str(exc)}
+        sys.stdout.write(json.dumps(response, ensure_ascii=False) + "\n")
+        sys.stdout.flush()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fable V2 execution broker")
+    parser.add_argument("--workspace", required=True, type=Path)
+    parser.add_argument("--allow-executable", action="append", default=[])
+    args = parser.parse_args(argv)
+    allowed = tuple(args.allow_executable) or BrokerPolicy.allowed_executables
+    policy = BrokerPolicy(workspace=args.workspace, allowed_executables=allowed)
+    serve(ExecutionBroker(policy))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fable_v2/execution_broker.py
+++ b/fable_v2/execution_broker.py
@@ -10,7 +10,7 @@ or an equivalent hardened isolation layer.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import argparse
 import hashlib
 import hmac
@@ -30,6 +30,9 @@ class BrokerPolicy:
     allowed_executables: tuple[str, ...] = ("python", "python3", "pytest")
     max_output_bytes: int = 1_000_000
     write_token_digest: str | None = None
+    resolved_executables: dict[str, str] = field(
+        init=False, default_factory=dict, repr=False, compare=False
+    )  # populated from trusted PATH at startup
 
     def __post_init__(self) -> None:
         workspace = self.workspace.expanduser().resolve()
@@ -39,12 +42,24 @@ class BrokerPolicy:
             raise ValueError("max_output_bytes must be positive")
         if not self.allowed_executables:
             raise ValueError("at least one executable must be allowlisted")
+        resolved: dict[str, str] = {}
+        normalized_names: list[str] = []
+        for item in self.allowed_executables:
+            requested = Path(item).expanduser()
+            located = requested if requested.is_absolute() else Path(shutil.which(str(requested)) or "")
+            if not located or not located.exists() or not located.is_file():
+                continue
+            absolute = str(located.resolve())
+            key = os.path.normcase(Path(item).name)
+            if key in resolved and os.path.normcase(resolved[key]) != os.path.normcase(absolute):
+                raise ValueError(f"ambiguous executable allowlist entry: {item}")
+            resolved[key] = absolute
+            normalized_names.append(Path(item).name)
+        if not resolved:
+            raise ValueError("no allowlisted executable could be resolved at broker startup")
         object.__setattr__(self, "workspace", workspace)
-        object.__setattr__(
-            self,
-            "allowed_executables",
-            tuple(Path(item).name for item in self.allowed_executables),
-        )
+        object.__setattr__(self, "allowed_executables", tuple(dict.fromkeys(normalized_names)))
+        object.__setattr__(self, "resolved_executables", resolved)
 
 
 class ExecutionBroker:
@@ -65,10 +80,7 @@ class ExecutionBroker:
         self._writes_unlocked = False
 
     def probe(self) -> dict[str, Any]:
-        available = [
-            executable for executable in self.policy.allowed_executables
-            if shutil.which(executable)
-        ]
+        available = list(self.policy.resolved_executables)
         return {
             "host": "fable-execution-broker",
             "capabilities": ["execute_command", "inspect_files", "probe_capabilities"],
@@ -130,14 +142,23 @@ class ExecutionBroker:
         argv = tuple(command)
         if not argv or any(not isinstance(item, str) or not item for item in argv):
             raise ValueError("command must be a non-empty sequence of strings")
-        executable = Path(argv[0]).name
+        requested_executable = Path(argv[0])
+        executable = requested_executable.name
         executable_key = Path(executable).stem.lower()
         is_interpreter = (
             executable_key in self.READ_LOCKED_INTERPRETERS
             or executable_key.startswith("python")
         )
-        if executable not in self.policy.allowed_executables:
+        registered_path = self.policy.resolved_executables.get(os.path.normcase(executable))
+        if not registered_path:
             raise PermissionError(f"executable is not allowlisted: {executable}")
+        requested_path = requested_executable if requested_executable.is_absolute() else Path(
+            shutil.which(str(requested_executable)) or ""
+        )
+        if not requested_path or not requested_path.exists():
+            raise PermissionError(f"executable cannot be resolved: {argv[0]}")
+        if os.path.normcase(str(requested_path.resolve())) != os.path.normcase(registered_path):
+            raise PermissionError("executable path does not match its startup registration")
         if is_interpreter and not self._writes_unlocked:
             raise PermissionError(
                 "general interpreters and shells are blocked while workspace writes are locked"
@@ -150,7 +171,7 @@ class ExecutionBroker:
         env = {"PATH": os.environ.get("PATH", ""), "PYTHONUNBUFFERED": "1"}
         try:
             completed = subprocess.run(
-                argv,
+                (registered_path, *argv[1:]),
                 cwd=directory,
                 env=env,
                 stdin=subprocess.DEVNULL,
@@ -177,8 +198,9 @@ class ExecutionBroker:
             encoded = value.encode("utf-8")[: self.policy.max_output_bytes]
             return encoded.decode("utf-8", errors="ignore") + "\n[truncated]"
 
+        executed_argv = (registered_path, *argv[1:])
         return {
-            "command": list(argv),
+            "command": list(executed_argv),
             "cwd": str(directory.relative_to(self.policy.workspace)),
             "exit_code": exit_code,
             "timed_out": timed_out,
@@ -216,13 +238,32 @@ def serve(broker: ExecutionBroker) -> None:
         sys.stdout.flush()
 
 
+def _load_write_token_digest() -> str | None:
+    """Load write authorization from administrator-controlled configuration."""
+    digest = os.environ.get("FABLE_BROKER_WRITE_TOKEN_DIGEST", "").strip()
+    digest_file = os.environ.get("FABLE_BROKER_WRITE_TOKEN_DIGEST_FILE", "").strip()
+    if digest and digest_file:
+        raise ValueError("configure only one write-token digest source")
+    if digest_file:
+        digest = Path(digest_file).read_text(encoding="utf-8").strip()
+    if not digest:
+        return None
+    if len(digest) != 64 or any(char not in "0123456789abcdefABCDEF" for char in digest):
+        raise ValueError("write-token digest must be a SHA-256 hexadecimal string")
+    return digest.lower()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Fable V2 execution broker")
     parser.add_argument("--workspace", required=True, type=Path)
     parser.add_argument("--allow-executable", action="append", default=[])
     args = parser.parse_args(argv)
     allowed = tuple(args.allow_executable) or BrokerPolicy.allowed_executables
-    policy = BrokerPolicy(workspace=args.workspace, allowed_executables=allowed)
+    policy = BrokerPolicy(
+        workspace=args.workspace,
+        allowed_executables=allowed,
+        write_token_digest=_load_write_token_digest(),
+    )
     serve(ExecutionBroker(policy))
     return 0
 

--- a/fable_v2/execution_broker.py
+++ b/fable_v2/execution_broker.py
@@ -18,6 +18,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -84,7 +85,9 @@ class ExecutionBroker:
         available = list(self.policy.resolved_executables)
         return {
             "host": "fable-execution-broker",
-            "capabilities": ["execute_command", "inspect_files", "probe_capabilities"],
+            "capabilities": [
+                "execute_command", "inspect_files", "probe_capabilities", "write_file"
+            ],
             "available_executables": available,
             "writes_enabled": self._writes_unlocked,
             "read_locked_interpreters": sorted(self.READ_LOCKED_INTERPRETERS),
@@ -116,6 +119,26 @@ class ExecutionBroker:
     def _authorize_write(self) -> None:
         if not self._writes_unlocked:
             raise PermissionError("workspace writes are locked")
+
+    def inspect_files(self, relative_path: str, max_bytes: int | None = None) -> dict[str, Any]:
+        """Read one workspace file with a bounded response."""
+        target = self._safe_path(relative_path)
+        if not target.is_file():
+            raise ValueError("inspect path must be a file inside the workspace")
+        limit = self.policy.max_output_bytes if max_bytes is None else int(max_bytes)
+        if limit < 1:
+            raise ValueError("max_bytes must be positive")
+        limit = min(limit, self.policy.max_output_bytes)
+        with target.open("rb") as handle:
+            raw = handle.read(limit + 1)
+        truncated = len(raw) > limit
+        raw = raw[:limit]
+        return {
+            "path": str(target.relative_to(self.policy.workspace)),
+            "content": raw.decode("utf-8", errors="replace"),
+            "content_hash": hashlib.sha256(raw).hexdigest(),
+            "truncated": truncated,
+        }
 
     def write_file(self, relative_path: str, content: str) -> dict[str, Any]:
         self._authorize_write()
@@ -175,50 +198,115 @@ class ExecutionBroker:
         if not directory.is_dir():
             raise ValueError("cwd must be a directory inside the workspace")
         env = {"PATH": os.environ.get("PATH", ""), "PYTHONUNBUFFERED": "1"}
+        process: subprocess.Popen[bytes] | None = None
+        output_limit = self.policy.max_output_bytes
+        captured = {"stdout": bytearray(), "stderr": bytearray()}
+        output_limited = threading.Event()
+        kill_lock = threading.Lock()
+
+        def stop_process() -> None:
+            if process is None:
+                return
+            with kill_lock:
+                if process.poll() is not None:
+                    return
+                try:
+                    if os.name == "posix":
+                        os.killpg(process.pid, signal.SIGKILL)
+                    else:
+                        process.kill()
+                except (ProcessLookupError, PermissionError):
+                    pass
+
+        def drain(name: str, stream: Any) -> None:
+            bucket = captured[name]
+            while True:
+                chunk = stream.read(64 * 1024)
+                if not chunk:
+                    return
+                remaining = output_limit - len(bucket)
+                if remaining <= 0:
+                    output_limited.set()
+                    stop_process()
+                    continue
+                if len(chunk) > remaining:
+                    bucket.extend(chunk[:remaining])
+                    output_limited.set()
+                    stop_process()
+                else:
+                    bucket.extend(chunk)
+
+        executed_argv = (registered_path, *argv[1:])
         try:
-            completed = subprocess.run(
-                (registered_path, *argv[1:]),
+            process = subprocess.Popen(
+                executed_argv,
                 cwd=directory,
                 env=env,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
                 shell=False,
-                timeout=timeout_seconds,
-                check=False,
+                start_new_session=(os.name == "posix"),
+                creationflags=(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                               if os.name == "nt" else 0),
             )
-            stdout = completed.stdout
-            stderr = completed.stderr
-            timed_out = False
-            exit_code = completed.returncode
-        except subprocess.TimeoutExpired as exc:
-            stdout = exc.stdout or ""
-            stderr = exc.stderr or ""
-            timed_out = True
-            exit_code = None
+            assert process.stdout is not None and process.stderr is not None
+            readers = [
+                threading.Thread(target=drain, args=("stdout", process.stdout), daemon=True),
+                threading.Thread(target=drain, args=("stderr", process.stderr), daemon=True),
+            ]
+            for reader in readers:
+                reader.start()
+            try:
+                exit_code = process.wait(timeout=timeout_seconds)
+                timed_out = False
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                stop_process()
+                exit_code = None
+            for reader in readers:
+                reader.join(timeout=5)
+            if process.poll() is None:
+                stop_process()
+                process.wait(timeout=5)
+        finally:
+            if process is not None:
+                if process.stdout is not None:
+                    process.stdout.close()
+                if process.stderr is not None:
+                    process.stderr.close()
+
+        stdout = bytes(captured["stdout"]).decode("utf-8", errors="replace")
+        stderr = bytes(captured["stderr"]).decode("utf-8", errors="replace")
 
         def truncate(value: str) -> str:
-            if len(value.encode("utf-8")) <= self.policy.max_output_bytes:
+            # Readers enforce this bound before decoding; this is only a
+            # defensive guard for future callers that supply strings directly.
+            encoded = value.encode("utf-8")
+            if len(encoded) <= output_limit:
                 return value
-            encoded = value.encode("utf-8")[: self.policy.max_output_bytes]
-            return encoded.decode("utf-8", errors="ignore") + "\n[truncated]"
+            return encoded[:output_limit].decode("utf-8", errors="ignore") + "\n[truncated]"
 
-        executed_argv = (registered_path, *argv[1:])
         return {
             "command": list(executed_argv),
             "cwd": str(directory.relative_to(self.policy.workspace)),
             "exit_code": exit_code,
             "timed_out": timed_out,
+            "output_limited": output_limited.is_set(),
             "stdout": truncate(stdout),
             "stderr": truncate(stderr),
-            "success": exit_code == 0 and not timed_out,
+            "success": exit_code == 0 and not timed_out and not output_limited.is_set(),
         }
 
     def handle(self, request: dict[str, Any]) -> dict[str, Any]:
         action = request.get("action")
-        if action == "probe":
+        if action in {"probe", "probe_capabilities"}:
             return self.probe()
+        if action == "inspect_files":
+            return self.inspect_files(
+                request.get("path", ""),
+                max_bytes=request.get("max_bytes"),
+            )
         if action == "execute_command":
             return self.execute_command(
                 request.get("command", ()),

--- a/fable_v2/protocol.py
+++ b/fable_v2/protocol.py
@@ -287,6 +287,9 @@ class VerificationResult:
     # ``in_process`` describes where the result came from; it is not proof of
     # trust. Only an external broker may issue ``process_attested`` results.
     trust_boundary: str = ""
+    # Commitment to the candidate plus every referenced receipt/evidence object.
+    # The runtime populates this before computing ``runtime_attestation``.
+    candidate_graph_hash: str = ""
     runtime_attestation: str = ""
 
     def __post_init__(self) -> None:

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -132,9 +132,14 @@ class FableRun:
 
     def attach_evidence(self, evidence: Evidence) -> None:
         with self._lock:
-            self._attach_evidence(evidence)
+            self._validate_evidence(evidence)
+            if evidence.evidence_id in self.evidence:
+                raise ValueError(f"duplicate evidence: {evidence.evidence_id}")
+            self.evidence[evidence.evidence_id] = evidence
+            self._event("evidence_attached", evidence_id=evidence.evidence_id,
+                        receipt_id=evidence.receipt_id)
 
-    def _attach_evidence(self, evidence: Evidence) -> None:
+    def _validate_evidence(self, evidence: Evidence) -> None:
         if evidence.session_id != self.session_id:
             raise ValueError("evidence belongs to a different session")
         receipt = self.receipts.get(evidence.receipt_id)
@@ -146,24 +151,14 @@ class FableRun:
             raise PermissionError("evidence is not bound to the receipt output hash")
         if evidence.content_hash != receipt.output_hash:
             raise PermissionError("evidence content hash does not match receipt output hash")
-        if evidence.evidence_id in self.evidence:
-            raise ValueError(f"duplicate evidence: {evidence.evidence_id}")
-        self.evidence[evidence.evidence_id] = evidence
-        self._event("evidence_attached", evidence_id=evidence.evidence_id,
-                    receipt_id=evidence.receipt_id)
 
-    def _record_attested_verification(self, result: VerificationResult) -> None:
-        """Store a result after ``execute_verifier`` has attested it."""
+    def _validate_attested_verification(self, result: VerificationResult) -> None:
+        """Validate every immutable verdict field and its candidate binding."""
         if result.session_id != self.session_id:
             raise ValueError("verification belongs to a different session")
         candidate = self.candidates.get(result.candidate_id)
         if candidate is None:
             raise ValueError("verification references an unknown candidate")
-        if result.verification_id in self.verifications:
-            raise ValueError(f"duplicate verification: {result.verification_id}")
-        if any(v.candidate_id == result.candidate_id and v.verifier == result.verifier
-               for v in self.verifications.values()):
-            raise ValueError("verifier already produced a result for this candidate")
         if not result.inspected_candidate:
             raise PermissionError("verification must be produced by an executed verifier")
         if result.trust_boundary not in VerificationPolicy.TRUST_BOUNDARY_RANK:
@@ -185,6 +180,17 @@ class FableRun:
             )
         if result.passed and not result.evidence_ids:
             raise PermissionError("a passing verification must cite candidate evidence")
+
+    def _record_attested_verification(self, result: VerificationResult) -> None:
+        """Store a result after ``execute_verifier`` has attested it."""
+        if result.session_id != self.session_id:
+            raise ValueError("verification belongs to a different session")
+        if result.verification_id in self.verifications:
+            raise ValueError(f"duplicate verification: {result.verification_id}")
+        if any(v.candidate_id == result.candidate_id and v.verifier == result.verifier
+               for v in self.verifications.values()):
+            raise ValueError("verifier already produced a result for this candidate")
+        self._validate_attested_verification(result)
         self.state = RunState.VERIFYING
         self.verifications[result.verification_id] = result
         self._event("verification_recorded", verification_id=result.verification_id,
@@ -203,11 +209,11 @@ class FableRun:
         )
 
     def _attestation(self, result: VerificationResult) -> str:
-        payload = "|".join((result.verification_id, result.candidate_id,
-                             result.candidate_hash, result.verifier,
-                             result.verifier_class, result.trust_boundary))
-        return hmac.new(self._attestation_secret, payload.encode("utf-8"),
-                        hashlib.sha256).hexdigest()
+        """MAC every immutable verdict field, excluding the MAC itself."""
+        payload = result.to_dict()
+        payload.pop("runtime_attestation", None)
+        digest = canonical_hash(payload).encode("utf-8")
+        return hmac.new(self._attestation_secret, digest, hashlib.sha256).hexdigest()
 
     def execute_verifier(self, verifier: RegisteredVerifier, candidate_id: str) -> VerificationResult:
         """Run and attest an in-process verifier against one exact candidate.
@@ -389,15 +395,32 @@ class FableRun:
                    "evidence_ids": tuple(item.get("evidence_ids", ()))})
             for item in data.get("candidates", [])
         }
-        run.evidence = {item["evidence_id"]: Evidence(**item)
-                        for item in data.get("evidence", [])}
-        run.verifications = {
-            item["verification_id"]: VerificationResult(
+        for candidate in run.candidates.values():
+            if any(receipt_id not in run.receipts for receipt_id in candidate.receipt_ids):
+                raise ValueError("candidate references an unknown restored receipt")
+        run.evidence = {}
+        for item in data.get("evidence", []):
+            evidence = Evidence(**item)
+            run._validate_evidence(evidence)
+            if evidence.evidence_id in run.evidence:
+                raise ValueError("duplicate restored evidence")
+            run.evidence[evidence.evidence_id] = evidence
+        for candidate in run.candidates.values():
+            if any(evidence_id not in run.evidence for evidence_id in candidate.evidence_ids):
+                raise ValueError("candidate references an unknown restored evidence item")
+        run.verifications = {}
+        seen_verifier_candidates: set[tuple[str, str]] = set()
+        for item in data.get("verifications", []):
+            result = VerificationResult(
                 **{**item,
                    "reasons": tuple(item.get("reasons", ())),
                    "evidence_ids": tuple(item.get("evidence_ids", ()))})
-            for item in data.get("verifications", [])
-        }
+            pair = (result.verifier, result.candidate_id)
+            if pair in seen_verifier_candidates:
+                raise ValueError("duplicate restored verifier verdict")
+            run._validate_attested_verification(result)
+            run.verifications[result.verification_id] = result
+            seen_verifier_candidates.add(pair)
         run.events = copy.deepcopy(data.get("events", []))
         run.final_candidate_id = data.get("final_candidate_id")
         run.invalidated_verifiers = dict(data.get("invalidated_verifiers", {}))

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -152,6 +152,32 @@ class FableRun:
         if evidence.content_hash != receipt.output_hash:
             raise PermissionError("evidence content hash does not match receipt output hash")
 
+    def _candidate_graph_hash(self, candidate: Candidate) -> str:
+        """Commit to a candidate and every receipt/evidence object it references."""
+        receipts = []
+        for receipt_id in candidate.receipt_ids:
+            receipt = self.receipts.get(receipt_id)
+            if receipt is None:
+                raise ValueError("candidate references an unknown receipt")
+            receipts.append({
+                "receipt_id": receipt_id,
+                "object_hash": canonical_hash(receipt.to_dict()),
+            })
+        evidence = []
+        for evidence_id in candidate.evidence_ids:
+            item = self.evidence.get(evidence_id)
+            if item is None:
+                raise ValueError("candidate references unknown evidence")
+            evidence.append({
+                "evidence_id": evidence_id,
+                "object_hash": canonical_hash(item.to_dict()),
+            })
+        return canonical_hash({
+            "candidate": candidate.to_dict(),
+            "receipts": receipts,
+            "evidence": evidence,
+        })
+
     def _validate_attested_verification(self, result: VerificationResult) -> None:
         """Validate every immutable verdict field and its candidate binding."""
         if result.session_id != self.session_id:
@@ -165,6 +191,11 @@ class FableRun:
             raise PermissionError("verification has no recognized trust boundary")
         if result.candidate_hash != canonical_hash(candidate.artifact):
             raise PermissionError("verification was not produced for the current candidate artifact")
+        expected_graph = self._candidate_graph_hash(candidate)
+        if not result.candidate_graph_hash or not hmac.compare_digest(
+            result.candidate_graph_hash, expected_graph
+        ):
+            raise PermissionError("verification is not bound to the current candidate dependency graph")
         expected = self._attestation(result)
         if not hmac.compare_digest(result.runtime_attestation, expected):
             raise PermissionError("verification has no valid runtime attestation")
@@ -266,6 +297,7 @@ class FableRun:
             inspected_candidate=True,
             independent=bool(getattr(verifier, "independent", False)),
             trust_boundary=trust_boundary,
+            candidate_graph_hash=self._candidate_graph_hash(candidate),
         )
         result = replace(result, runtime_attestation=self._attestation(result))
         self._record_attested_verification(result)
@@ -394,15 +426,23 @@ class FableRun:
         secret = data.get("attestation_secret")
         if secret:
             run._attestation_secret = bytes.fromhex(secret)
-        run.receipts = {item["receipt_id"]: ToolReceipt(**item)
-                        for item in data.get("receipts", [])}
-        run.candidates = {
-            item["candidate_id"]: Candidate(
+        run.receipts = {}
+        for item in data.get("receipts", []):
+            receipt = ToolReceipt(**item)
+            if receipt.session_id != run.session_id:
+                raise ValueError("restored tool receipt belongs to a different session")
+            if receipt.receipt_id in run.receipts:
+                raise ValueError("duplicate restored tool receipt")
+            run.receipts[receipt.receipt_id] = receipt
+        run.candidates = {}
+        for item in data.get("candidates", []):
+            candidate = Candidate(
                 **{**item,
                    "receipt_ids": tuple(item.get("receipt_ids", ())),
                    "evidence_ids": tuple(item.get("evidence_ids", ()))})
-            for item in data.get("candidates", [])
-        }
+            if candidate.candidate_id in run.candidates:
+                raise ValueError("duplicate restored candidate")
+            run.candidates[candidate.candidate_id] = candidate
         for candidate in run.candidates.values():
             if any(receipt_id not in run.receipts for receipt_id in candidate.receipt_ids):
                 raise ValueError("candidate references an unknown restored receipt")

--- a/fable_v2/runtime.py
+++ b/fable_v2/runtime.py
@@ -280,12 +280,20 @@ class FableRun:
             self._event("verifier_invalidated", verifier=verifier.strip(),
                         reason=reason.strip())
 
-    def successful_capabilities(self) -> set[str]:
-        return {r.capability for r in self.receipts.values() if r.success}
+    def successful_capabilities(self, candidate_id: str | None = None) -> set[str]:
+        """Return successful capabilities, scoped to a candidate when given."""
+        if candidate_id is None:
+            receipts = self.receipts.values()
+        else:
+            candidate = self.candidates.get(candidate_id)
+            if candidate is None:
+                raise ValueError(f"unknown candidate: {candidate_id}")
+            receipts = (self.receipts[receipt_id] for receipt_id in candidate.receipt_ids)
+        return {receipt.capability for receipt in receipts if receipt.success}
 
     def missing_requirements(self, candidate_id: str | None = None) -> list[str]:
         missing: list[str] = []
-        used = self.successful_capabilities()
+        used = self.successful_capabilities(candidate_id)
         for capability in self.task.required_capabilities:
             if capability not in used:
                 missing.append(f"required capability not completed: {capability}")

--- a/install.ps1
+++ b/install.ps1
@@ -35,7 +35,7 @@ Write-Host @"
 / __/  / ___ | / /_/ // /___ / /___ /_____/ /  / // /_/ // /_/ // /___   
 /_/    /_/  |_|/_____//_____//_____/      /_/  /_/ \____//_____//_____/   
                                                                           
-  Deterministic System 2 Deliberation • Mechanical Time-Lock • 0 Dependencies
+  V1 Legacy MCP Server • Deterministic System 2 Deliberation • 0 Dependencies
 ================================================================================
 "@ -ForegroundColor Magenta
 
@@ -80,11 +80,11 @@ Write-Success "Cognitive skill installed to: $SkillTarget"
 
 # Step 5: Run Automated Invariant & MCP Test Suites
 if (-not $SkipTests) {
-    Write-Step "Executing Fable-Engine verification suite..."
+    Write-Step "Executing Fable-Engine V1 verification suite (legacy MCP server)..."
     $testScript = Join-Path $EngineSource "test_server.py"
     $testOutput = python $testScript 2>&1
     if ($LASTEXITCODE -eq 0) {
-        Write-Success "Fable-Engine verification suite PASSED."
+        Write-Success "Fable-Engine V1 verification suite PASSED."
     } else {
         Write-Host $testOutput -ForegroundColor Red
         throw "Fable-Engine verification failed; installation aborted."
@@ -144,7 +144,7 @@ if ($RegisterMcp) {
 Write-Host @"
 
 ================================================================================
- [SUCCESS] Fable-Mode installation completed successfully!
+ [SUCCESS] Fable-Mode V1 installation completed successfully!
 ================================================================================
 
  MCP Host Configuration:
@@ -168,4 +168,5 @@ Write-Host @"
  Ready to deliberate! Trigger Fable-Mode in your MCP host or set an authority budget.
 ================================================================================
 "@ -ForegroundColor Green
+
 

--- a/install.sh
+++ b/install.sh
@@ -2,12 +2,12 @@
 set -e
 
 echo "=========================================================="
-echo "  Fable-Mode: Deterministic System 2 Cognitive Engine"
+echo "  Fable-Mode V1: Legacy MCP Session Engine"
 echo "=========================================================="
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "[+] Running Fable-Engine test suite..."
+echo "[+] Running Fable-Engine V1 test suite (legacy MCP server)..."
 python3 "$SCRIPT_DIR/fable_engine/test_server.py"
 echo "[✓] All tests passed (100%)."
 
@@ -22,6 +22,7 @@ mkdir -p "$MCP_DIR"
 cp "$SCRIPT_DIR/fable_engine/fable_session.json" "$MCP_DIR/fable_session.json"
 
 echo "=========================================================="
-echo "  Fable-Mode installation complete!"
+echo "  Fable-Mode V1 installation complete (legacy MCP server)!"
 echo "=========================================================="
+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,10 @@ classifiers = [
 ]
 
 [project.scripts]
+# Legacy V1 MCP entry point. Existing installations continue to use this.
 fable-engine = "fable_engine.server:main"
+fable-v1 = "fable_engine.server:main"
+# V2 execution boundary. The portable runtime is imported from fable_v2.
+fable-v2-broker = "fable_v2.execution_broker:main"
+
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ setup(
     install_requires=[],
     entry_points={
         "console_scripts": [
+            # Legacy V1 MCP entry point.
             "fable-engine=fable_engine.server:main",
+            "fable-v1=fable_engine.server:main",
+            # V2 process execution boundary.
+            "fable-v2-broker=fable_v2.execution_broker:main",
         ],
     },
     classifiers=[
@@ -18,3 +22,4 @@ setup(
         "Operating System :: OS Independent",
     ],
 )
+

--- a/tests/test_execution_broker.py
+++ b/tests/test_execution_broker.py
@@ -23,14 +23,23 @@ class ExecutionBrokerTests(unittest.TestCase):
     def tearDown(self):
         self.tempdir.cleanup()
 
-    def test_command_is_allowlisted_and_runs_without_shell(self):
+    def test_interpreters_are_blocked_before_write_authorization(self):
+        # shell=False does not stop Python from opening files directly.
+        with self.assertRaises(PermissionError):
+            self.broker.execute_command([
+                sys.executable, "-c", "open('unauthorized.txt', 'w').write('bypass')"
+            ])
+        self.assertFalse((self.workspace / "unauthorized.txt").exists())
+
+    def test_command_is_allowlisted_and_runs_after_authorization(self):
+        with self.assertRaises(PermissionError):
+            self.broker.execute_command(["sh", "-c", "echo escaped"])
+        self.broker.write_file("authorized.txt", "unlock", "admin-token")
         result = self.broker.execute_command([
             sys.executable, "-c", "print('broker-ok')"
         ])
         self.assertTrue(result["success"])
         self.assertIn("broker-ok", result["stdout"])
-        with self.assertRaises(PermissionError):
-            self.broker.execute_command(["sh", "-c", "echo escaped"])
 
     def test_paths_cannot_escape_workspace(self):
         with self.assertRaises(PermissionError):

--- a/tests/test_execution_broker.py
+++ b/tests/test_execution_broker.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -35,7 +36,7 @@ class ExecutionBrokerTests(unittest.TestCase):
     def test_command_is_allowlisted_and_runs_after_authorization(self):
         with self.assertRaises(PermissionError):
             self.broker.execute_command(["sh", "-c", "echo escaped"])
-        self.broker.write_file("authorized.txt", "unlock", "admin-token")
+        self.broker.unlock_writes("admin-token")
         result = self.broker.execute_command([
             sys.executable, "-c", "print('broker-ok')"
         ])
@@ -49,19 +50,23 @@ class ExecutionBrokerTests(unittest.TestCase):
             self.broker.execute_command([str(fake), "-c", "print('wrong')"])
 
     def test_paths_cannot_escape_workspace(self):
+        self.broker.unlock_writes("admin-token")
         with self.assertRaises(PermissionError):
-            self.broker.write_file("../outside.txt", "blocked", "admin-token")
+            self.broker.write_file("../outside.txt", "blocked")
 
     def test_writes_are_locked_until_admin_authorization(self):
         with self.assertRaises(PermissionError):
             self.broker.write_file("result.txt", "blocked")
         with self.assertRaises(PermissionError):
-            self.broker.write_file("result.txt", "blocked", "wrong-token")
-        result = self.broker.write_file("result.txt", "accepted", "admin-token")
+            self.broker.unlock_writes("wrong-token")
+        self.broker.unlock_writes("admin-token")
+        result = self.broker.write_file("result.txt", "accepted")
         self.assertTrue(result["writes_enabled"])
         self.assertEqual((self.workspace / "result.txt").read_text(), "accepted")
 
+    @unittest.skipUnless(os.name != "nt", "inherited admin FD test is POSIX-only")
     def test_broker_is_available_as_a_json_lines_child_process(self):
+        admin_read, admin_write = os.pipe()
         env = os.environ.copy()
         env["FABLE_BROKER_WRITE_TOKEN_DIGEST"] = hashlib.sha256(
             b"admin-token"
@@ -69,19 +74,32 @@ class ExecutionBrokerTests(unittest.TestCase):
         process = subprocess.Popen(
             [sys.executable, "-m", "fable_v2.execution_broker",
              "--workspace", str(self.workspace),
-             "--allow-executable", self.executable],
+             "--allow-executable", self.executable,
+             "--admin-fd", str(admin_read)],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, text=True, env=env,
+            pass_fds=(admin_read,),
         )
+        os.close(admin_read)
         try:
-            process.stdin.write(json.dumps({"action": "probe"}) + "\n")
-            process.stdin.flush()
-            response = json.loads(process.stdout.readline())
+            os.write(admin_write, (json.dumps({
+                "action": "unlock_writes", "token": "admin-token",
+            }) + "\n").encode("utf-8"))
+            os.close(admin_write)
+            response = None
+            for _ in range(50):
+                process.stdin.write(json.dumps({"action": "probe"}) + "\n")
+                process.stdin.flush()
+                response = json.loads(process.stdout.readline())
+                if response["result"].get("writes_enabled"):
+                    break
+                time.sleep(0.01)
             self.assertTrue(response["ok"])
             self.assertIn("execute_command", response["result"]["capabilities"])
+            self.assertTrue(response["result"]["writes_enabled"])
             process.stdin.write(json.dumps({
                 "action": "write_file", "path": "cli.txt",
-                "content": "cli-authorized", "token": "admin-token",
+                "content": "cli-authorized",
             }) + "\n")
             process.stdin.flush()
             write_response = json.loads(process.stdout.readline())

--- a/tests/test_execution_broker.py
+++ b/tests/test_execution_broker.py
@@ -43,6 +43,30 @@ class ExecutionBrokerTests(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIn("broker-ok", result["stdout"])
 
+    def test_inspect_files_is_implemented_and_bounded(self):
+        target = self.workspace / "input.txt"
+        target.write_text("hello world", encoding="utf-8")
+        result = self.broker.handle({"action": "inspect_files", "path": "input.txt"})
+        self.assertEqual(result["content"], "hello world")
+        self.assertFalse(result["truncated"])
+        self.assertEqual(result["content_hash"], hashlib.sha256(b"hello world").hexdigest())
+        self.assertEqual(self.broker.handle({"action": "probe_capabilities"}), self.broker.probe())
+
+    def test_subprocess_output_is_bounded_before_capture(self):
+        limited = ExecutionBroker(BrokerPolicy(
+            workspace=self.workspace,
+            allowed_executables=(self.executable,),
+            max_output_bytes=4096,
+            write_token_digest=hashlib.sha256(b"admin-token").hexdigest(),
+        ))
+        limited.unlock_writes("admin-token")
+        result = limited.execute_command([
+            sys.executable, "-c", "import sys; sys.stdout.write('x' * 100000000)"
+        ])
+        self.assertTrue(result["output_limited"])
+        self.assertFalse(result["success"])
+        self.assertLessEqual(len(result["stdout"].encode("utf-8")), 4096)
+
     def test_same_basename_from_different_path_is_rejected(self):
         fake = self.workspace / self.executable
         fake.write_text("not the registered executable")

--- a/tests/test_execution_broker.py
+++ b/tests/test_execution_broker.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -41,6 +42,12 @@ class ExecutionBrokerTests(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIn("broker-ok", result["stdout"])
 
+    def test_same_basename_from_different_path_is_rejected(self):
+        fake = self.workspace / self.executable
+        fake.write_text("not the registered executable")
+        with self.assertRaises(PermissionError):
+            self.broker.execute_command([str(fake), "-c", "print('wrong')"])
+
     def test_paths_cannot_escape_workspace(self):
         with self.assertRaises(PermissionError):
             self.broker.write_file("../outside.txt", "blocked", "admin-token")
@@ -55,12 +62,16 @@ class ExecutionBrokerTests(unittest.TestCase):
         self.assertEqual((self.workspace / "result.txt").read_text(), "accepted")
 
     def test_broker_is_available_as_a_json_lines_child_process(self):
+        env = os.environ.copy()
+        env["FABLE_BROKER_WRITE_TOKEN_DIGEST"] = hashlib.sha256(
+            b"admin-token"
+        ).hexdigest()
         process = subprocess.Popen(
             [sys.executable, "-m", "fable_v2.execution_broker",
              "--workspace", str(self.workspace),
              "--allow-executable", self.executable],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, text=True,
+            stderr=subprocess.PIPE, text=True, env=env,
         )
         try:
             process.stdin.write(json.dumps({"action": "probe"}) + "\n")
@@ -68,6 +79,14 @@ class ExecutionBrokerTests(unittest.TestCase):
             response = json.loads(process.stdout.readline())
             self.assertTrue(response["ok"])
             self.assertIn("execute_command", response["result"]["capabilities"])
+            process.stdin.write(json.dumps({
+                "action": "write_file", "path": "cli.txt",
+                "content": "cli-authorized", "token": "admin-token",
+            }) + "\n")
+            process.stdin.flush()
+            write_response = json.loads(process.stdout.readline())
+            self.assertTrue(write_response["ok"])
+            self.assertEqual((self.workspace / "cli.txt").read_text(), "cli-authorized")
         finally:
             process.terminate()
             process.wait(timeout=5)

--- a/tests/test_execution_broker.py
+++ b/tests/test_execution_broker.py
@@ -1,0 +1,71 @@
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from fable_v2 import BrokerPolicy, ExecutionBroker
+
+
+class ExecutionBrokerTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tempdir.name)
+        self.executable = Path(sys.executable).name
+        self.broker = ExecutionBroker(BrokerPolicy(
+            workspace=self.workspace,
+            allowed_executables=(self.executable,),
+            write_token_digest=hashlib.sha256(b"admin-token").hexdigest(),
+        ))
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_command_is_allowlisted_and_runs_without_shell(self):
+        result = self.broker.execute_command([
+            sys.executable, "-c", "print('broker-ok')"
+        ])
+        self.assertTrue(result["success"])
+        self.assertIn("broker-ok", result["stdout"])
+        with self.assertRaises(PermissionError):
+            self.broker.execute_command(["sh", "-c", "echo escaped"])
+
+    def test_paths_cannot_escape_workspace(self):
+        with self.assertRaises(PermissionError):
+            self.broker.write_file("../outside.txt", "blocked", "admin-token")
+
+    def test_writes_are_locked_until_admin_authorization(self):
+        with self.assertRaises(PermissionError):
+            self.broker.write_file("result.txt", "blocked")
+        with self.assertRaises(PermissionError):
+            self.broker.write_file("result.txt", "blocked", "wrong-token")
+        result = self.broker.write_file("result.txt", "accepted", "admin-token")
+        self.assertTrue(result["writes_enabled"])
+        self.assertEqual((self.workspace / "result.txt").read_text(), "accepted")
+
+    def test_broker_is_available_as_a_json_lines_child_process(self):
+        process = subprocess.Popen(
+            [sys.executable, "-m", "fable_v2.execution_broker",
+             "--workspace", str(self.workspace),
+             "--allow-executable", self.executable],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, text=True,
+        )
+        try:
+            process.stdin.write(json.dumps({"action": "probe"}) + "\n")
+            process.stdin.flush()
+            response = json.loads(process.stdout.readline())
+            self.assertTrue(response["ok"])
+            self.assertIn("execute_command", response["result"]["capabilities"])
+        finally:
+            process.terminate()
+            process.wait(timeout=5)
+            process.stdin.close()
+            process.stdout.close()
+            process.stderr.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 
@@ -301,6 +302,31 @@ class FableV2RuntimeTests(unittest.TestCase):
             list(pool.map(self.run.register_candidate, candidates))
         self.assertEqual(len(self.run.candidates), 33)
         self.run.validate_event_history()
+
+    def test_restored_verdict_is_checked_against_complete_attestation(self):
+        self.run.execute_verifier(FunctionVerifier(
+            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0),
+            evidence_ids=("e-tests",),
+        ), "candidate-001")
+        self.run.execute_verifier(FunctionVerifier(
+            "independent-review", lambda candidate: (True, ("review passed",), 1.0),
+            verifier_class="independent", independent=True, evidence_ids=("e-tests",),
+        ), "candidate-001")
+        payload = self.run.to_dict()
+        self.assertEqual(FableRun.from_dict(payload).status()["verifications"], 2)
+        mutations = {
+            "passed": False,
+            "reasons": ["tampered"],
+            "evidence_ids": [],
+            "score": 0.0,
+            "independent": True,
+            "inspected_candidate": False,
+        }
+        for field, value in mutations.items():
+            tampered = copy.deepcopy(payload)
+            tampered["verifications"][0][field] = value
+            with self.assertRaises(PermissionError, msg=field):
+                FableRun.from_dict(tampered)
 
     def test_tampered_event_history_is_rejected_on_restore(self):
         payload = self.run.to_dict()

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -70,6 +70,39 @@ class FableV2RuntimeTests(unittest.TestCase):
         with self.assertRaises(PermissionError):
             self.run.finalize("candidate-001")
 
+    def test_required_capabilities_are_candidate_scoped(self):
+        task = TaskSpec(
+            task_id="scoped-capabilities", objective="x", definition_of_done=("done",),
+            required_capabilities=("inspect_files", "run_tests"),
+            verification_policy=VerificationPolicy(
+                required_verifier_classes=("deterministic",),
+                minimum_passing_verifiers=1,
+                require_independent=False,
+            ),
+        )
+        run = new_run("session-scoped", task)
+        inspect = ToolReceipt.from_result(
+            receipt_id="r-scope-inspect", session_id="session-scoped",
+            capability="inspect_files", tool_name="grep", tool_input="x",
+            tool_output="inspection", success=True,
+        )
+        tests = ToolReceipt.from_result(
+            receipt_id="r-scope-tests", session_id="session-scoped",
+            capability="run_tests", tool_name="pytest", tool_input="x",
+            tool_output="tests", success=True,
+        )
+        run.record_receipt(inspect)
+        run.record_receipt(tests)
+        run.register_candidate(Candidate(
+            "inspect-only", "session-scoped", "inspection", "a", (inspect.receipt_id,)
+        ))
+        run.register_candidate(Candidate(
+            "tests-only", "session-scoped", "tests", "b", (tests.receipt_id,)
+        ))
+        self.assertEqual(run.successful_capabilities(), {"inspect_files", "run_tests"})
+        self.assertIn("run_tests", " ".join(run.missing_requirements("inspect-only")))
+        self.assertIn("inspect_files", " ".join(run.missing_requirements("tests-only")))
+
     def test_finalization_requires_every_declared_capability(self):
         task = TaskSpec(
             task_id="missing", objective="x", definition_of_done=("done",),

--- a/tests/test_fable_v2.py
+++ b/tests/test_fable_v2.py
@@ -361,6 +361,27 @@ class FableV2RuntimeTests(unittest.TestCase):
             with self.assertRaises(PermissionError, msg=field):
                 FableRun.from_dict(tampered)
 
+    def test_dependency_graph_tampering_is_rejected_on_restore(self):
+        self.run.execute_verifier(FunctionVerifier(
+            "deterministic-tests", lambda candidate: (True, ("tests pass",), 1.0),
+            evidence_ids=("e-tests",),
+        ), "candidate-001")
+        payload = self.run.to_dict()
+        self.assertTrue(payload["verifications"][0]["candidate_graph_hash"])
+        mutations = []
+        candidate_tamper = copy.deepcopy(payload)
+        candidate_tamper["candidates"][0]["receipt_ids"] = ["r-inspect"]
+        mutations.append(candidate_tamper)
+        receipt_tamper = copy.deepcopy(payload)
+        receipt_tamper["receipts"][0]["capability"] = "run_tests"
+        mutations.append(receipt_tamper)
+        evidence_tamper = copy.deepcopy(payload)
+        evidence_tamper["evidence"][0]["metadata"] = {"tampered": True}
+        mutations.append(evidence_tamper)
+        for tampered in mutations:
+            with self.assertRaises(PermissionError):
+                FableRun.from_dict(tampered)
+
     def test_tampered_event_history_is_rejected_on_restore(self):
         payload = self.run.to_dict()
         payload["events"][0]["type"] = "tampered"


### PR DESCRIPTION
## Summary

Fable V2 is a portable, evidence-gated runtime foundation. This PR now closes the verification-attestation, checkpoint dependency-graph, broker authorization, executable-path, resource-boundary, capability, and CI coverage gaps identified during review.

## Verification and checkpoint integrity

- Attestation MACs the complete immutable `VerificationResult` payload.
- Direct/model-supplied verification results are rejected.
- Verdicts bind to the exact candidate artifact.
- `candidate_graph_hash` commits to the complete candidate state and canonical hashes of every referenced `ToolReceipt` and `Evidence` object.
- The commitment covers candidate receipt/evidence references, receipt capability/success/tool/timestamp/metadata/output state, and evidence provenance/content state.
- Restore recomputes the dependency-graph commitment before accepting a stored verdict.
- Restore rejects duplicate or cross-session receipts/candidates and validates event history.
- The serialized HMAC secret remains explicitly documented as an experimental checkpoint limitation; production deployments must use an external key store/signing broker.

## Execution broker

- V1 and V2 entry points are explicitly separated.
- Allowlisted executables resolve to trusted absolute paths at startup; basename-only substitution is rejected.
- Commands use `shell=False`, workspace containment, and locked writes.
- General interpreters/shells are blocked before write authorization.
- Administrative write unlock is isolated from model JSON requests through a separate inherited POSIX admin FD (`--admin-fd`); Windows adapters should use a protected named pipe/control handle.
- CLI loads the write-token digest from administrator-controlled environment/file configuration.
- stdout/stderr are drained concurrently into bounded buffers; exceeding `max_output_bytes` terminates the child/process group instead of accumulating unbounded `subprocess.run()` output.
- `inspect_files` is implemented with bounded reads, and `probe_capabilities` is supported as an action. Advertised capabilities match implemented protocol actions.

## CI and validation

The checked-in workflow retains the Ubuntu/Windows Python 3.10/3.11/3.12 matrix and explicitly runs:

- `python fable_engine/test_server.py`
- `python -m unittest discover -s tests -v`
- `python -m py_compile fable_v2/*.py`

Local V2 validation: 33 tests passed, Python compilation passed, and `bash -n install.sh` passed.

## Scope

The broker is a process/policy boundary, not a complete OS sandbox. Hostile workloads still require OS-enforced read-only/container/VM isolation and separately controlled writable layers. Multiplicative improvement targets are hypotheses to be measured on held-out benchmarks, not claims from plumbing tests.