### PR TITLE
Add verified Windows and macOS release downloaders

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
             artifact: linux-x86_64
           - os: macos-13
             artifact: macos-x86_64
+          - os: macos-14
+            artifact: macos-arm64
           - os: windows-latest
             artifact: windows-x86_64
     steps:
@@ -209,3 +211,4 @@ jobs:
           set -eu
           test -n "${GITHUB_REF_NAME}"
           gh release create "${GITHUB_REF_NAME}" upload/* --title "Fable Mode ${GITHUB_REF_NAME}" --generate-notes
+

--- a/README.md
+++ b/README.md
@@ -319,14 +319,84 @@ Fable-Mode is distributed as a self-contained console runtime. It installs Fable
 
 ### Release artifacts and trust status
 
-Artifacts are **not available until a version tag build succeeds**. The tagged workflow currently produces these architecture-specific names (the exact version is inserted in the GitHub Release):
+Artifacts are **not available until a version tag build succeeds**. When a tagged
+workflow completes successfully, it publishes these architecture-specific names
+(the exact version is inserted in the GitHub Release):
 
 - `fable-mode-vX.Y.Z-windows-x86_64.zip` (contains `fable-mode.exe`)
-- `fable-mode-vX.Y.Z-macos-x86_64.zip` (contains `fable-mode`; macOS builds are not universal2)
+- `fable-mode-vX.Y.Z-macos-x86_64.zip` (contains `fable-mode`)
+- `fable-mode-vX.Y.Z-macos-arm64.zip` (contains `fable-mode`)
 - `fable-mode-vX.Y.Z-linux-x86_64.tar.gz` (contains `fable-mode`)
-- `SHA256SUMS` is published with each release.
+- `SHA256SUMS` (one SHA-256 line for each archive)
 
-For a tag `$TAG` (for example `v1.2.0`), download the matching `fable-mode-$TAG-<platform>-<arch>.*` asset and `SHA256SUMS` from that GitHub Release. The tagged workflow is the source of truth for availability; this README does not promise that an artifact or Release exists before that workflow has completed. Verify the archive's SHA-256 against `SHA256SUMS`, then extract it. Run `fable-mode install --yes` (or `fable-mode.exe install --yes` on Windows). `verify` performs a resource-manifest check and bounded MCP `initialize`/`tools/list` handshake. These artifacts are unsigned and macOS artifacts are not notarized; no signing or notarization claim is made.
+The macOS x86_64 job uses `macos-13` and the macOS arm64 job uses the
+repository workflow's `macos-14` runner. These are separate archives, not a
+universal2 binary. The Windows and macOS downloaders below select only the
+matching architecture and exact expected asset name.
+
+The release workflow is the source of truth: this README does not promise that
+an artifact or Release exists before a tagged build has completed successfully.
+Both downloaders query the latest GitHub Release. A repository with no Release
+(or a Release missing the matching archive or `SHA256SUMS`) fails clearly rather
+than falling back to a source checkout.
+
+#### Windows x86_64 downloader
+
+From a checkout of this repository, run PowerShell on a 64-bit Windows machine:
+
+```powershell
+.\download-windows.ps1
+# Or choose an install directory explicitly:
+.\download-windows.ps1 -InstallDir "$HOME\.local\fable-mode"
+```
+
+The default destination is `$HOME\fable-mode`; the script prints the full path
+to `fable-mode.exe` and a suggested next command. It downloads the exact
+`fable-mode-vX.Y.Z-windows-x86_64.zip` and `SHA256SUMS` assets, checks the
+archive's SHA-256 before extraction, and does not execute the downloaded file.
+It fails on unsupported Windows architectures, missing assets, no Release, an
+invalid checksum, or an invalid archive layout. Install and verify the runtime
+with the printed path, for example:
+
+```powershell
+& "$HOME\fable-mode\fable-mode.exe" install --yes
+& "$HOME\fable-mode\fable-mode.exe" verify
+```
+
+#### macOS downloader
+
+From a checkout of this repository, run the script in a macOS Terminal:
+
+```sh
+chmod +x ./download-macos.sh
+./download-macos.sh
+# Or choose an install directory explicitly:
+./download-macos.sh "$HOME/.local/bin/fable-mode-release"
+```
+
+The default destination is `$HOME/.local/bin`. The script detects `x86_64` or
+`arm64`, selects `fable-mode-vX.Y.Z-macos-x86_64.zip` or
+`fable-mode-vX.Y.Z-macos-arm64.zip`, and requires the standard macOS
+`curl`, `unzip`, `shasum`, `plutil`, and related built-ins. It verifies the
+archive against `SHA256SUMS` with `shasum` **before** extraction, sets the
+installed file executable, and prints the installed path plus the next command.
+It does not require Python and never evaluates GitHub response data as shell
+code. Unsupported architectures, missing commands/assets, no Release, bad
+checksums, and unexpected ZIP layouts fail without installing a partial file.
+
+Install and verify with the path printed by the script (the default path is
+shown here):
+
+```sh
+"$HOME/.local/bin/fable-mode" install --yes
+"$HOME/.local/bin/fable-mode" verify
+```
+
+These downloaders fetch **unsigned binaries**. The workflow publishes
+SHA-256 checksums for transport/integrity verification, but signing,
+certificate validation, and macOS notarization are not included. Review the
+release and its checksums before use; checksum verification is not a
+cryptographic publisher signature.
 
 ### Source-mode prerequisites and support boundary
 

--- a/download-macos.sh
+++ b/download-macos.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# Download and install the latest checksum-verified (but unsigned)
+# Fable-Mode macOS release for the current CPU architecture.
+set -eu
+
+REPO='REX-codebase/fable-mode'
+API_URL="https://api.github.com/repos/$REPO/releases/latest"
+INSTALL_DIR=${1:-"$HOME/.local/bin"}
+TMP_DIR=''
+TEMP_OUTPUT=''
+
+fail() {
+    printf 'download-macos: ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "required macOS command '$1' was not found"
+}
+
+# These are the standard macOS tools used below.  In particular, plutil is
+# used as a JSON parser; no API response is ever interpreted as shell code.
+for command_name in curl mktemp uname plutil unzip shasum awk grep rm cp mkdir chmod mv; do
+    require_command "$command_name"
+done
+
+[ "$(uname -s)" = 'Darwin' ] || fail 'this downloader supports macOS only'
+
+MACHINE=$(uname -m)
+case "$MACHINE" in
+    x86_64) ARCH='x86_64' ;;
+    arm64) ARCH='arm64' ;;
+    *) fail "unsupported macOS architecture '$MACHINE' (supported: x86_64, arm64)" ;;
+esac
+
+# mktemp creates a private directory (umask also protects downloaded files).
+umask 077
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fable-mode-download.XXXXXX") || fail 'could not create a secure temporary directory'
+cleanup() {
+    if [ -n "$TEMP_OUTPUT" ]; then
+        rm -f "$TEMP_OUTPUT"
+    fi
+    if [ -n "$TMP_DIR" ]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT HUP INT TERM
+
+API_FILE="$TMP_DIR/release.json"
+ASSETS_FILE="$TMP_DIR/assets.json"
+
+# Keep the status code separate so a genuine GitHub 404 can be reported as
+# "no release", while network and server errors remain distinct failures.
+HTTP_STATUS=$(curl -sS -L --proto '=https' --proto-redir '=https' \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'User-Agent: fable-mode-release-downloader' \
+    -o "$API_FILE" -w '%{http_code}' "$API_URL") \
+    || fail 'could not contact the GitHub Releases API'
+case "$HTTP_STATUS" in
+    200) ;;
+    404) fail 'no GitHub Release exists yet for this repository' ;;
+    *) fail "GitHub Releases API returned HTTP $HTTP_STATUS" ;;
+esac
+
+plutil -lint -o /dev/null "$API_FILE" >/dev/null 2>&1 \
+    || fail 'GitHub returned an invalid release JSON response'
+
+TAG=$(plutil -extract tag_name raw -o - "$API_FILE" 2>/dev/null) \
+    || fail 'latest release did not contain a tag name'
+printf '%s\n' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    || fail "latest release has an unsupported tag '$TAG'"
+
+ASSET_NAME="fable-mode-${TAG}-macos-${ARCH}.zip"
+EXPECTED_ARCHIVE_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET_NAME}"
+EXPECTED_SUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/SHA256SUMS"
+
+plutil -extract assets json -o "$ASSETS_FILE" "$API_FILE" 2>/dev/null \
+    || fail 'latest release did not contain a usable assets list'
+
+archive_url=''
+sums_url=''
+asset_index=0
+while asset_name=$(plutil -extract "${asset_index}.name" raw -o - "$ASSETS_FILE" 2>/dev/null); do
+    asset_url=$(plutil -extract "${asset_index}.browser_download_url" raw -o - "$ASSETS_FILE" 2>/dev/null) \
+        || fail "release asset '$asset_name' did not contain a download URL"
+    case "$asset_name" in
+        "$ASSET_NAME")
+            [ -z "$archive_url" ] || fail "release contains duplicate asset '$ASSET_NAME'"
+            [ "$asset_url" = "$EXPECTED_ARCHIVE_URL" ] \
+                || fail "release asset '$ASSET_NAME' has an unexpected download URL"
+            archive_url=$asset_url
+            ;;
+        SHA256SUMS)
+            [ -z "$sums_url" ] || fail 'release contains duplicate SHA256SUMS assets'
+            [ "$asset_url" = "$EXPECTED_SUMS_URL" ] \
+                || fail 'release SHA256SUMS asset has an unexpected download URL'
+            sums_url=$asset_url
+            ;;
+    esac
+    asset_index=$((asset_index + 1))
+done
+
+[ -n "$archive_url" ] || fail "latest release has no macOS $ARCH asset named '$ASSET_NAME'"
+[ -n "$sums_url" ] || fail 'latest release has no SHA256SUMS asset'
+
+ARCHIVE_FILE="$TMP_DIR/$ASSET_NAME"
+SUMS_FILE="$TMP_DIR/SHA256SUMS"
+curl -fsS -L --proto '=https' --proto-redir '=https' \
+    -H 'User-Agent: fable-mode-release-downloader' -o "$ARCHIVE_FILE" "$archive_url" \
+    || fail "could not download '$ASSET_NAME'"
+curl -fsS -L --proto '=https' --proto-redir '=https' \
+    -H 'User-Agent: fable-mode-release-downloader' -o "$SUMS_FILE" "$sums_url" \
+    || fail 'could not download SHA256SUMS'
+
+# Accept only a conventional SHA-256 line for this exact, generated basename.
+# The checksum text is data: it is never interpreted or passed to a shell.
+CHECKSUM=$(awk -v target="$ASSET_NAME" '
+    NF == 2 && length($1) == 64 && $1 !~ /[^[:xdigit:]]/ {
+        name = $2
+        sub(/^\*/, "", name)
+        if (name == target) {
+            if (found) exit 2
+            value = $1
+            found = 1
+        }
+    }
+    END {
+        if (!found) exit 3
+        print value
+    }
+' "$SUMS_FILE") || fail "SHA256SUMS has no unambiguous checksum for '$ASSET_NAME'"
+
+# Verify through shasum itself, using a generated one-line check file whose
+# basename and hash have both been validated above.
+VERIFY_FILE="$TMP_DIR/verify.txt"
+printf '%s  %s\n' "$CHECKSUM" "$ASSET_NAME" > "$VERIFY_FILE"
+(
+    cd "$TMP_DIR" || exit 1
+    shasum -a 256 -c "$VERIFY_FILE"
+) || fail 'SHA-256 checksum mismatch; archive was not extracted'
+
+# The release builder puts exactly one executable at the archive root.  Reject
+# all other layouts before unzip, including path traversal entries.
+ARCHIVE_ENTRIES=$(unzip -Z1 "$ARCHIVE_FILE" 2>/dev/null) \
+    || fail 'downloaded archive is not a readable ZIP file'
+[ "$ARCHIVE_ENTRIES" = 'fable-mode' ] \
+    || fail 'downloaded archive has an unexpected layout; refusing to extract'
+EXTRACT_DIR="$TMP_DIR/extracted"
+mkdir "$EXTRACT_DIR"
+unzip -q "$ARCHIVE_FILE" -d "$EXTRACT_DIR" \
+    || fail 'could not extract the verified archive'
+[ -f "$EXTRACT_DIR/fable-mode" ] || fail "archive did not contain executable 'fable-mode'"
+
+if [ -e "$INSTALL_DIR" ] && [ ! -d "$INSTALL_DIR" ]; then
+    fail "install path exists but is not a directory: $INSTALL_DIR"
+fi
+mkdir -p "$INSTALL_DIR" || fail "could not create install directory: $INSTALL_DIR"
+OUTPUT_FILE="$INSTALL_DIR/fable-mode"
+# A same-directory temporary file plus rename prevents a partial executable
+# from being presented if copying is interrupted.
+TEMP_OUTPUT=$(mktemp "$INSTALL_DIR/.fable-mode.tmp.XXXXXX") \
+    || fail "could not create temporary output in: $INSTALL_DIR"
+cp "$EXTRACT_DIR/fable-mode" "$TEMP_OUTPUT" \
+    || fail 'could not copy executable to the install directory'
+chmod 755 "$TEMP_OUTPUT" || fail 'could not set executable permissions'
+mv -f "$TEMP_OUTPUT" "$OUTPUT_FILE" || fail 'could not install executable atomically'
+TEMP_OUTPUT=''
+
+printf 'Installed verified executable: %s\n' "$OUTPUT_FILE"
+printf 'Next: "%s" install --yes\n' "$OUTPUT_FILE"

--- a/download-windows.ps1
+++ b/download-windows.ps1
@@ -1,0 +1,179 @@
+# Download and install the latest Fable-Mode Windows x86_64 release.
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string] $InstallDir = (Join-Path ([Environment]::GetFolderPath('UserProfile')) 'fable-mode')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Repository = 'REX-codebase/fable-mode'
+$ApiUrl = "https://api.github.com/repos/$Repository/releases/latest"
+$TempDir = $null
+
+function Fail([string] $Message) {
+    throw "download-windows: ERROR: $Message"
+}
+
+try {
+    # Windows PowerShell does not expose $IsWindows; this check works in both
+    # Windows PowerShell 5.1 and PowerShell 7.  Only the published target is
+    # accepted, rather than relying on a downloaded binary to fail later.
+    if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
+        Fail 'this downloader supports Windows only'
+    }
+    $nativeArchitecture = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrEmpty($nativeArchitecture)) {
+        $nativeArchitecture = $env:PROCESSOR_ARCHITECTURE
+    }
+    if ($nativeArchitecture -ne 'AMD64' -or -not [Environment]::Is64BitOperatingSystem) {
+        Fail "unsupported Windows architecture '$nativeArchitecture' (supported: x86_64/AMD64)"
+    }
+
+    # New-TemporaryFile creates a file with a random name.  Replace that file
+    # with a directory so all untrusted downloads remain private and scoped.
+    $temporaryMarker = New-TemporaryFile
+    $TempDir = $temporaryMarker.FullName
+    Remove-Item -LiteralPath $TempDir -Force
+    New-Item -ItemType Directory -LiteralPath $TempDir -Force | Out-Null
+
+    $headers = @{
+        Accept = 'application/vnd.github+json'
+        'User-Agent' = 'fable-mode-release-downloader'
+    }
+    $releaseFile = Join-Path $TempDir 'release.json'
+    try {
+        Invoke-WebRequest -Uri $ApiUrl -Headers $headers -UseBasicParsing -OutFile $releaseFile
+    }
+    catch {
+        $statusCode = $null
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+        if ($statusCode -eq 404) {
+            Fail 'no GitHub Release exists yet for this repository'
+        }
+        Fail "could not contact the GitHub Releases API$(if ($statusCode) { " (HTTP $statusCode)" })"
+    }
+
+    try {
+        $release = Get-Content -LiteralPath $releaseFile -Raw | ConvertFrom-Json
+    }
+    catch {
+        Fail 'GitHub returned an invalid release JSON response'
+    }
+    if ($null -eq $release -or $null -eq $release.tag_name) {
+        Fail 'latest release did not contain a tag name'
+    }
+    $tag = [string]$release.tag_name
+    if ($tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') {
+        Fail "latest release has an unsupported tag '$tag'"
+    }
+    if ($null -eq $release.assets) {
+        Fail 'latest release did not contain a usable assets list'
+    }
+
+    $archiveName = "fable-mode-$tag-windows-x86_64.zip"
+    $expectedArchiveUrl = "https://github.com/$Repository/releases/download/$tag/$archiveName"
+    $expectedSumsUrl = "https://github.com/$Repository/releases/download/$tag/SHA256SUMS"
+    $archiveAsset = @($release.assets | Where-Object { [string]$_.name -ceq $archiveName })
+    $sumsAsset = @($release.assets | Where-Object { [string]$_.name -ceq 'SHA256SUMS' })
+    if ($archiveAsset.Count -eq 0) {
+        Fail "latest release has no Windows x86_64 asset named '$archiveName'"
+    }
+    if ($archiveAsset.Count -ne 1) {
+        Fail "release contains duplicate asset '$archiveName'"
+    }
+    if ($sumsAsset.Count -eq 0) {
+        Fail 'latest release has no SHA256SUMS asset'
+    }
+    if ($sumsAsset.Count -ne 1) {
+        Fail 'release contains duplicate SHA256SUMS assets'
+    }
+    $archiveUrl = [string]$archiveAsset[0].browser_download_url
+    $sumsUrl = [string]$sumsAsset[0].browser_download_url
+    if ($archiveUrl -cne $expectedArchiveUrl) {
+        Fail "release asset '$archiveName' has an unexpected download URL"
+    }
+    if ($sumsUrl -cne $expectedSumsUrl) {
+        Fail 'release SHA256SUMS asset has an unexpected download URL'
+    }
+
+    $archiveFile = Join-Path $TempDir $archiveName
+    $sumsFile = Join-Path $TempDir 'SHA256SUMS'
+    try {
+        Invoke-WebRequest -Uri $archiveUrl -Headers $headers -UseBasicParsing -OutFile $archiveFile
+        Invoke-WebRequest -Uri $sumsUrl -Headers $headers -UseBasicParsing -OutFile $sumsFile
+    }
+    catch {
+        Fail 'could not download the selected release assets'
+    }
+
+    # Parse only a strict SHA-256 line whose filename is the expected basename.
+    # Checksum content is data and is never evaluated as PowerShell code.
+    $checksum = $null
+    foreach ($line in (Get-Content -LiteralPath $sumsFile)) {
+        if ($line -match '^\s*([0-9A-Fa-f]{64})\s+\*?([^\s]+)\s*$' -and $Matches[2] -ceq $archiveName) {
+            if ($null -ne $checksum) {
+                Fail "SHA256SUMS has duplicate checksums for '$archiveName'"
+            }
+            $checksum = $Matches[1].ToLowerInvariant()
+        }
+    }
+    if ($null -eq $checksum) {
+        Fail "SHA256SUMS has no unambiguous checksum for '$archiveName'"
+    }
+    $actualChecksum = (Get-FileHash -LiteralPath $archiveFile -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualChecksum -cne $checksum) {
+        Fail 'SHA-256 checksum mismatch; archive was not extracted'
+    }
+
+    # Expand only after verification.  Inspect the ZIP entries first so a
+    # path-traversal entry or unexpected layout is rejected before extraction.
+    # Expand-Archive does not execute files; this script never launches the
+    # downloaded executable.
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($archiveFile)
+    try {
+        $entries = @($zip.Entries)
+        if ($entries.Count -ne 1 -or $entries[0].FullName -cne 'fable-mode.exe') {
+            Fail "downloaded archive has an unexpected layout; refusing to extract"
+        }
+    }
+    finally {
+        $zip.Dispose()
+    }
+    $extractDir = Join-Path $TempDir 'extracted'
+    Expand-Archive -LiteralPath $archiveFile -DestinationPath $extractDir -Force
+    $executable = Join-Path $extractDir 'fable-mode.exe'
+    if (-not (Test-Path -LiteralPath $executable -PathType Leaf)) {
+        Fail "archive did not contain executable 'fable-mode.exe' at its root"
+    }
+    $destination = [System.IO.Path]::GetFullPath($InstallDir)
+    if (Test-Path -LiteralPath $destination -PathType Leaf) {
+        Fail "install path exists but is not a directory: $destination"
+    }
+    New-Item -ItemType Directory -LiteralPath $destination -Force | Out-Null
+    $outputFile = Join-Path $destination 'fable-mode.exe'
+    # Copy to a same-directory temporary name then rename, avoiding a partial
+    # executable if copying is interrupted.  Move-Item never executes it.
+    $temporaryOutput = Join-Path $destination ('.fable-mode.exe.tmp.' + [Guid]::NewGuid().ToString('N'))
+    try {
+        Copy-Item -LiteralPath $executable -Destination $temporaryOutput -Force
+        Move-Item -LiteralPath $temporaryOutput -Destination $outputFile -Force
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporaryOutput) {
+            Remove-Item -LiteralPath $temporaryOutput -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Write-Host "Installed verified executable: $outputFile"
+    Write-Host "Next: & `"$outputFile`" install --yes"
+}
+finally {
+    if ($null -ne $TempDir -and (Test-Path -LiteralPath $TempDir)) {
+        Remove-Item -LiteralPath $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/test_release_downloaders.py
+++ b/tests/test_release_downloaders.py
@@ -1,0 +1,57 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReleaseDownloaderStaticTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.macos = (ROOT / "download-macos.sh").read_text(encoding="utf-8")
+        cls.windows = (ROOT / "download-windows.ps1").read_text(encoding="utf-8")
+        cls.workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        cls.readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    def test_macos_is_network_free_of_python_and_shell_eval(self):
+        self.assertIn("set -eu", self.macos)
+        self.assertIn("plutil", self.macos)
+        self.assertIn("shasum -a 256 -c", self.macos)
+        self.assertNotRegex(self.macos, r"\bpython(?:3)?\b")
+        self.assertNotRegex(self.macos, r"\beval\b|\bsource\b|\bexec\b")
+        self.assertIn("trap cleanup EXIT HUP INT TERM", self.macos)
+
+    def test_downloaders_verify_before_extract_and_use_expected_names(self):
+        self.assertLess(self.macos.index("shasum -a 256 -c"), self.macos.index("unzip -q \"$ARCHIVE_FILE\""))
+        self.assertLess(self.windows.index("Get-FileHash"), self.windows.index("Expand-Archive"))
+        self.assertIn("fable-mode-${TAG}-macos-${ARCH}", self.macos)
+        self.assertIn('fable-mode-$tag-windows-x86_64.zip', self.windows)
+        self.assertIn("SHA256SUMS", self.macos)
+        self.assertIn("SHA256SUMS", self.windows)
+        self.assertNotRegex(self.windows, r"Invoke-Expression|\bIEX\b")
+
+    def test_workflow_and_readme_list_the_same_release_targets(self):
+        for artifact in (
+            "windows-x86_64",
+            "macos-x86_64",
+            "macos-arm64",
+            "linux-x86_64",
+        ):
+            self.assertIn(f"artifact: {artifact}", self.workflow)
+            self.assertIn(artifact, self.readme)
+        self.assertIn("os: macos-14", self.workflow)
+        self.assertIn("fable-mode-vX.Y.Z-macos-arm64.zip", self.readme)
+        self.assertIn("SHA256SUMS", self.readme)
+        self.assertIn("unsigned binaries", self.readme)
+        self.assertIn("notarization", self.readme)
+
+    def test_scripts_have_no_unquoted_download_path_as_shell_code(self):
+        # API and asset values must be quoted when passed to curl; this is a
+        # deliberately small regression guard for shell-injection mistakes.
+        self.assertNotRegex(self.macos, r"curl[^\n]*\$asset_url[^\n]*[^\"]\$asset_url")
+        self.assertIn('"$archive_url"', self.macos)
+        self.assertIn('"$sums_url"', self.macos)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds copy-paste downloaders for the packaged Windows and macOS executables.

- `download-windows.ps1` selects the latest Windows x86_64 release, verifies `SHA256SUMS`, validates the ZIP layout, and installs `fable-mode.exe` atomically.
- `download-macos.sh` selects x86_64 or arm64, verifies the checksum before extraction, validates the archive, and installs `fable-mode` atomically.
- Adds a macOS arm64 release build and documents both workflows in the README.
- Adds offline static consistency tests for the scripts, workflow, and documentation.

Artifacts remain unsigned and are only available after a successful tagged release build.

Validation: 103 unittest cases, V1 suite, compileall, shell syntax, and static checks pass.