### PR TITLE
Remove in-process exec() from red_team_code_review

### DIFF
--- a/fable_engine/actions/fleet.py
+++ b/fable_engine/actions/fleet.py
@@ -314,9 +314,17 @@ def _handle_record_breakage_report(arguments: Dict[str, Any]) -> str:
 def _handle_verify_red_team_remediation(arguments: Dict[str, Any]) -> str:
     action = arguments.get("action", "").strip().lower()
     session_name = arguments.get("session_name", "").strip()
-    session: Optional[FableSession] = None
     if not session_name:
         return "Error: 'session_name' is required for action 'verify_red_team_remediation'."
+
+    remediated_code = arguments.get("remediated_code") or arguments.get("target_code") or arguments.get("code") or ""
+    if not callable(remediated_code):
+        return (
+            "Error: Source-code strings cannot be evaluated in-process for security reasons. "
+            "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "
+            "Provide an executable Python Callable object in-process."
+        )
+
     session = get_or_load_session(session_name)
 
     report_id = arguments.get("report_id")
@@ -330,14 +338,6 @@ def _handle_verify_red_team_remediation(arguments: Dict[str, Any]) -> str:
 
     if not prior_report:
         return "Error: No prior breakage report found to verify. Provide 'report_id' or 'prior_report'."
-
-    remediated_code = arguments.get("remediated_code") or arguments.get("target_code") or arguments.get("code") or ""
-    if not callable(remediated_code):
-        return (
-            "Error: Source-code strings cannot be evaluated in-process for security reasons. "
-            "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "
-            "Provide an executable Python Callable object in-process."
-        )
     timeout_sec = float(arguments.get("timeout_seconds", 3.0))
     all_fixed, new_report = _get_swarm().verify_remediation(
         target_callable=remediated_code,

--- a/fable_engine/actions/fleet.py
+++ b/fable_engine/actions/fleet.py
@@ -190,12 +190,11 @@ def _handle_register_automation_pipeline(arguments: Dict[str, Any]) -> str:
 def _handle_red_team_code_review(arguments: Dict[str, Any]) -> str:
     action = arguments.get("action", "").strip().lower()
     session_name = arguments.get("session_name", "").strip()
-    session: Optional[FableSession] = None
     if not session_name:
         return "Error: 'session_name' is required for action 'red_team_code_review'."
     target_name = arguments.get("target_name", "system")
     code_snippet = arguments.get("target_code") or arguments.get("code_snippet") or arguments.get("code") or ""
-    if isinstance(code_snippet, str) and code_snippet.strip():
+    if not callable(code_snippet):
         return (
             "Error: Source-code strings cannot be evaluated in-process for security reasons. "
             "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "
@@ -206,7 +205,7 @@ def _handle_red_team_code_review(arguments: Dict[str, Any]) -> str:
 
     session = get_or_load_session(session_name)
     report = _get_swarm().run_full_review_cycle(
-        target_callable=code_snippet if callable(code_snippet) else None,
+        target_callable=code_snippet,
         target_name=target_name,
         custom_hypotheses=custom_hypotheses,
     )
@@ -333,7 +332,7 @@ def _handle_verify_red_team_remediation(arguments: Dict[str, Any]) -> str:
         return "Error: No prior breakage report found to verify. Provide 'report_id' or 'prior_report'."
 
     remediated_code = arguments.get("remediated_code") or arguments.get("target_code") or arguments.get("code") or ""
-    if isinstance(remediated_code, str) and remediated_code.strip():
+    if not callable(remediated_code):
         return (
             "Error: Source-code strings cannot be evaluated in-process for security reasons. "
             "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "

--- a/fable_engine/actions/fleet.py
+++ b/fable_engine/actions/fleet.py
@@ -203,8 +203,7 @@ def _handle_red_team_code_review(arguments: Dict[str, Any]) -> str:
     if code_snippet is not None and not callable(code_snippet):
         return (
             "Error: Source-code strings cannot be evaluated in-process for security reasons. "
-            "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "
-            "Provide an executable Python Callable object in-process."
+            "Dynamic source-code execution is disabled for public actions until an isolated sandbox executor is configured."
         )
 
     custom_hypotheses = arguments.get("custom_hypotheses") or arguments.get("hypotheses")
@@ -333,8 +332,7 @@ def _handle_verify_red_team_remediation(arguments: Dict[str, Any]) -> str:
     if remediated_code is not None and not callable(remediated_code):
         return (
             "Error: Source-code strings cannot be evaluated in-process for security reasons. "
-            "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "
-            "Provide an executable Python Callable object in-process."
+            "Dynamic source-code execution is disabled for public actions until an isolated sandbox executor is configured."
         )
 
     session = get_or_load_session(session_name)

--- a/fable_engine/actions/fleet.py
+++ b/fable_engine/actions/fleet.py
@@ -192,14 +192,21 @@ def _handle_red_team_code_review(arguments: Dict[str, Any]) -> str:
     session_name = arguments.get("session_name", "").strip()
     if not session_name:
         return "Error: 'session_name' is required for action 'red_team_code_review'."
+
     target_name = arguments.get("target_name", "system")
-    code_snippet = arguments.get("target_code") or arguments.get("code_snippet") or arguments.get("code") or ""
-    if not callable(code_snippet):
+    code_snippet = None
+    for k in ("target_code", "code_snippet", "code", "target_callable"):
+        if k in arguments and arguments[k] is not None:
+            code_snippet = arguments[k]
+            break
+
+    if code_snippet is not None and not callable(code_snippet):
         return (
             "Error: Source-code strings cannot be evaluated in-process for security reasons. "
             "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "
             "Provide an executable Python Callable object in-process."
         )
+
     custom_hypotheses = arguments.get("custom_hypotheses") or arguments.get("hypotheses")
     output_path = arguments.get("output_path")
 
@@ -317,8 +324,13 @@ def _handle_verify_red_team_remediation(arguments: Dict[str, Any]) -> str:
     if not session_name:
         return "Error: 'session_name' is required for action 'verify_red_team_remediation'."
 
-    remediated_code = arguments.get("remediated_code") or arguments.get("target_code") or arguments.get("code") or ""
-    if not callable(remediated_code):
+    remediated_code = None
+    for k in ("remediated_code", "target_code", "code_snippet", "code", "target_callable"):
+        if k in arguments and arguments[k] is not None:
+            remediated_code = arguments[k]
+            break
+
+    if remediated_code is not None and not callable(remediated_code):
         return (
             "Error: Source-code strings cannot be evaluated in-process for security reasons. "
             "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "

--- a/fable_engine/actions/fleet.py
+++ b/fable_engine/actions/fleet.py
@@ -195,12 +195,18 @@ def _handle_red_team_code_review(arguments: Dict[str, Any]) -> str:
         return "Error: 'session_name' is required for action 'red_team_code_review'."
     target_name = arguments.get("target_name", "system")
     code_snippet = arguments.get("target_code") or arguments.get("code_snippet") or arguments.get("code") or ""
+    if isinstance(code_snippet, str) and code_snippet.strip():
+        return (
+            "Error: Source-code strings cannot be evaluated in-process for security reasons. "
+            "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "
+            "Provide an executable Python Callable object in-process."
+        )
     custom_hypotheses = arguments.get("custom_hypotheses") or arguments.get("hypotheses")
     output_path = arguments.get("output_path")
 
     session = get_or_load_session(session_name)
     report = _get_swarm().run_full_review_cycle(
-        target_callable=code_snippet if code_snippet else None,
+        target_callable=code_snippet if callable(code_snippet) else None,
         target_name=target_name,
         custom_hypotheses=custom_hypotheses,
     )
@@ -327,6 +333,12 @@ def _handle_verify_red_team_remediation(arguments: Dict[str, Any]) -> str:
         return "Error: No prior breakage report found to verify. Provide 'report_id' or 'prior_report'."
 
     remediated_code = arguments.get("remediated_code") or arguments.get("target_code") or arguments.get("code") or ""
+    if isinstance(remediated_code, str) and remediated_code.strip():
+        return (
+            "Error: Source-code strings cannot be evaluated in-process for security reasons. "
+            "Dynamic source-code execution is disabled until an isolated sandbox executor is configured. "
+            "Provide an executable Python Callable object in-process."
+        )
     timeout_sec = float(arguments.get("timeout_seconds", 3.0))
     all_fixed, new_report = _get_swarm().verify_remediation(
         target_callable=remediated_code,

--- a/fable_engine/schema.py
+++ b/fable_engine/schema.py
@@ -478,11 +478,11 @@ TOOL_SCHEMA = {
             },
             "target_code": {
                 "type": "string",
-                "description": "Target module or function identifier under test. Source-code strings are unsupported in-process for security reasons."
+                "description": "Source-code string input. Dynamic target execution from source-code strings is disabled and requires a separate sandboxed executor."
             },
             "code_snippet": {
                 "type": "string",
-                "description": "Alternative alias for target module or function under review. Source-code strings are unsupported in-process for security reasons."
+                "description": "Alternative alias for source-code string input. Dynamic target execution from source-code strings is disabled and requires a separate sandboxed executor."
             },
             "custom_hypotheses": {
                 "description": "List or JSON string of custom adversarial hypotheses / attack vectors.",
@@ -494,7 +494,7 @@ TOOL_SCHEMA = {
             },
             "remediated_code": {
                 "type": "string",
-                "description": "Remediated target callable or function identifier submitted to verify against broken scenarios. Source-code strings are unsupported in-process for security reasons."
+                "description": "Remediated source-code string input. Dynamic target execution from source-code strings is disabled and requires a separate sandboxed executor."
             },
             "prior_report": {
                 "description": "Prior red-team breakage report dictionary or JSON string to verify remediation against.",

--- a/fable_engine/schema.py
+++ b/fable_engine/schema.py
@@ -478,11 +478,11 @@ TOOL_SCHEMA = {
             },
             "target_code": {
                 "type": "string",
-                "description": "Target module or function identifier under test. Note: dynamic in-process source-code string execution is disabled for security reasons."
+                "description": "Target module or function identifier under test. Source-code strings are unsupported in-process for security reasons."
             },
             "code_snippet": {
                 "type": "string",
-                "description": "Alternative alias or snippet for target module or function under review. Note: dynamic in-process source-code string execution is disabled for security reasons."
+                "description": "Alternative alias for target module or function under review. Source-code strings are unsupported in-process for security reasons."
             },
             "custom_hypotheses": {
                 "description": "List or JSON string of custom adversarial hypotheses / attack vectors.",
@@ -494,7 +494,7 @@ TOOL_SCHEMA = {
             },
             "remediated_code": {
                 "type": "string",
-                "description": "Remediated target callable or function identifier submitted to verify against broken scenarios. Note: dynamic in-process source-code string execution is disabled for security reasons."
+                "description": "Remediated target callable or function identifier submitted to verify against broken scenarios. Source-code strings are unsupported in-process for security reasons."
             },
             "prior_report": {
                 "description": "Prior red-team breakage report dictionary or JSON string to verify remediation against.",

--- a/fable_engine/schema.py
+++ b/fable_engine/schema.py
@@ -478,11 +478,11 @@ TOOL_SCHEMA = {
             },
             "target_code": {
                 "type": "string",
-                "description": "Target source code under test for adversarial red-teaming."
+                "description": "Target module or function identifier under test. Note: dynamic in-process source-code string execution is disabled for security reasons."
             },
             "code_snippet": {
                 "type": "string",
-                "description": "Alternative alias or snippet for target source code under review."
+                "description": "Alternative alias or snippet for target module or function under review. Note: dynamic in-process source-code string execution is disabled for security reasons."
             },
             "custom_hypotheses": {
                 "description": "List or JSON string of custom adversarial hypotheses / attack vectors.",
@@ -494,7 +494,7 @@ TOOL_SCHEMA = {
             },
             "remediated_code": {
                 "type": "string",
-                "description": "Remediated code submitted to verify against broken scenarios."
+                "description": "Remediated target callable or function identifier submitted to verify against broken scenarios. Note: dynamic in-process source-code string execution is disabled for security reasons."
             },
             "prior_report": {
                 "description": "Prior red-team breakage report dictionary or JSON string to verify remediation against.",

--- a/fable_engine/updater.py
+++ b/fable_engine/updater.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 logger = logging.getLogger("fable-engine.updater")
 
 BASELINE_LOBES: frozenset[str] = frozenset(
-    {"rust", "python", "design_3d", "research", "concurrency", "frontend_design", "process", "security"}
+    {"rust", "python", "design_3d", "research", "concurrency"}
 )
 
 _BG_LOCK = threading.Lock()

--- a/fable_engine/updater.py
+++ b/fable_engine/updater.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 logger = logging.getLogger("fable-engine.updater")
 
 BASELINE_LOBES: frozenset[str] = frozenset(
-    {"rust", "python", "design_3d", "research", "concurrency"}
+    {"rust", "python", "design_3d", "research", "concurrency", "frontend_design", "process", "security"}
 )
 
 _BG_LOCK = threading.Lock()

--- a/fable_v2/coder_fleet/red_team_swarm.py
+++ b/fable_v2/coder_fleet/red_team_swarm.py
@@ -8,14 +8,10 @@ Production-grade Red Team Swarm engine providing:
 """
 from __future__ import annotations
 
-import atexit
 import datetime
 import inspect
 import json
 import os
-import subprocess
-import sys
-import tempfile
 import threading
 import time
 import traceback

--- a/fable_v2/coder_fleet/red_team_swarm.py
+++ b/fable_v2/coder_fleet/red_team_swarm.py
@@ -244,36 +244,10 @@ class RedTeamSwarm:
                 except Exception:
                     self.plasticity_engine = None
 
-    @staticmethod
-    def _compile_code_to_callable(code: str) -> Callable[..., Any]:
-        """Safely compiles a python code string into an executable callable."""
-        scope: dict[str, Any] = {}
-        exec(code, scope, scope)
-
-        # Look for functions defined in scope
-        functions = [v for v in scope.values() if callable(v) and not isinstance(v, type)]
-        if functions:
-            return functions[-1]
-
-        # Look for classes
-        classes = [v for v in scope.values() if isinstance(v, type)]
-        if classes:
-            return classes[-1]
-
-        def _fallback_callable(*args: Any, **kwargs: Any) -> Any:
-            return scope.get("result", None)
-
-        return _fallback_callable
-
     def _resolve_callable(self, target: Any) -> Optional[Callable[..., Any]]:
-        """Resolves target callable from function, class, or code string."""
+        """Resolves target callable from function or class object. String targets are returned as None."""
         if callable(target):
             return target
-        if isinstance(target, str) and target.strip():
-            try:
-                return self._compile_code_to_callable(target)
-            except Exception:
-                return None
         return None
 
     def generate_break_scenarios(

--- a/fable_v2/coder_fleet/red_team_swarm.py
+++ b/fable_v2/coder_fleet/red_team_swarm.py
@@ -576,9 +576,11 @@ class RedTeamSwarm:
         timeout_seconds: float = 3.0,
         target_name: Optional[str] = None,
     ) -> RedTeamBreakageReport:
-        """Executes the break scenarios against target_callable with sandboxed execution.
+        """Executes the break scenarios against target_callable in-process.
 
-        Detects unhandled crashes, memory/resource leaks, invariant violations, and timeouts.
+        Executes trusted callable objects in the current process. Source-code strings are rejected
+        and require a separate sandboxed executor for dynamic execution. Detects unhandled crashes,
+        memory/resource leaks, invariant violations, and timeouts.
         """
         callable_fn = self._resolve_callable(target_callable)
         actual_name = target_name or getattr(callable_fn, "__name__", "target")

--- a/fable_v2/coder_fleet/red_team_swarm.py
+++ b/fable_v2/coder_fleet/red_team_swarm.py
@@ -247,174 +247,10 @@ class RedTeamSwarm:
                 except Exception:
                     self.plasticity_engine = None
 
-    def _create_isolated_subprocess_callable(self, code: str) -> Callable[..., Any]:
-        """Wraps Python code string in an isolated subprocess executor (no in-process exec)."""
-        proc_lock = threading.Lock()
-        proc_container: dict[str, Any] = {"proc": None, "target_name": "target"}
-
-        def _start_proc() -> None:
-            driver = f"""import json
-import sys
-import inspect
-import traceback
-
-code_str = {repr(code)}
-
-scope = {{}}
-try:
-    exec(code_str, scope, scope)
-except Exception as e:
-    sys.stderr.write(f"CompilationError: {{type(e).__name__}}: {{e}}\\n{{traceback.format_exc()}}\\n")
-    sys.exit(1)
-
-funcs = [v for k, v in scope.items() if callable(v) and not k.startswith("_") and not isinstance(v, type)]
-classes = [v for k, v in scope.items() if isinstance(v, type) and not k.startswith("_")]
-target = funcs[-1] if funcs else (classes[-1] if classes else None)
-
-if target is None:
-    sys.stderr.write("TypeError: No top-level function or class found in code snippet\\n")
-    sys.exit(1)
-
-print("__TARGET_NAME__:" + getattr(target, "__name__", "target"))
-sys.stdout.flush()
-
-while True:
-    line = sys.stdin.readline()
-    if not line:
-        break
-    try:
-        req = json.loads(line)
-        payload = req.get("payload")
-
-        try:
-            sig = inspect.signature(target)
-            has_params = len(sig.parameters) > 0
-        except Exception:
-            has_params = True
-
-        if has_params:
-            res = target(payload)
-        else:
-            res = target()
-        print(json.dumps({{"success": True, "result": str(res)}}))
-        sys.stdout.flush()
-    except Exception as e:
-        err_msg = f"{{type(e).__name__}}: {{e}}"
-        print(json.dumps({{"success": False, "error": err_msg, "traceback": traceback.format_exc()}}))
-        sys.stdout.flush()
-"""
-            temp_fd, temp_path = tempfile.mkstemp(suffix=".py", text=True)
-            try:
-                with os.fdopen(temp_fd, "w", encoding="utf-8") as f:
-                    f.write(driver)
-
-                proc = subprocess.Popen(
-                    [sys.executable, temp_path],
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    bufsize=1,
-                )
-                line = proc.stdout.readline() if proc.stdout else ""
-                if line.startswith("__TARGET_NAME__:"):
-                    proc_container["target_name"] = line.split(":", 1)[1].strip()
-                    proc_container["proc"] = proc
-                    atexit.register(lambda p=proc: p.poll() is None and p.terminate())
-                else:
-                    stderr = proc.stderr.read() if proc.stderr else ""
-                    proc.terminate()
-                    proc_container["proc"] = None
-                    raise RuntimeError(f"Subprocess initialization failed: {stderr or line}")
-            finally:
-                if os.path.exists(temp_path):
-                    try:
-                        os.remove(temp_path)
-                    except OSError:
-                        pass
-
-        def _isolated_runner(payload: Any = None) -> Any:
-            with proc_lock:
-                proc = proc_container.get("proc")
-                if not proc or proc.poll() is not None:
-                    _start_proc()
-                    proc = proc_container.get("proc")
-
-                try:
-                    try:
-                        payload_json = json.dumps(payload)
-                    except Exception:
-                        payload_json = json.dumps(str(payload))
-
-                    req_str = json.dumps({"payload_raw": payload_json, "payload": payload}) + "\n"
-                    assert proc and proc.stdin and proc.stdout
-                    proc.stdin.write(req_str)
-                    proc.stdin.flush()
-
-                    resp_line = proc.stdout.readline()
-                    if not resp_line:
-                        stderr = proc.stderr.read() if proc.stderr else ""
-                        proc_container["proc"] = None
-                        if "MemoryError" in stderr:
-                            raise MemoryError(stderr)
-                        if "AttributeError" in stderr:
-                            raise AttributeError(stderr)
-                        if "KeyError" in stderr:
-                            raise KeyError(stderr)
-                        if "ValueError" in stderr:
-                            raise ValueError(stderr)
-                        if "TypeError" in stderr:
-                            raise TypeError(stderr)
-                        if "RecursionError" in stderr:
-                            raise RecursionError(stderr)
-                        if "ZeroDivisionError" in stderr:
-                            raise ZeroDivisionError(stderr)
-                        if "AssertionError" in stderr:
-                            raise AssertionError(stderr)
-                        raise RuntimeError(stderr or "Subprocess exited unexpectedly")
-
-                    data = json.loads(resp_line)
-                    if data.get("success"):
-                        return data.get("result")
-
-                    err_msg = data.get("error", "Error in subprocess")
-                    if err_msg.startswith("MemoryError"):
-                        raise MemoryError(err_msg)
-                    if err_msg.startswith("AttributeError"):
-                        raise AttributeError(err_msg)
-                    if err_msg.startswith("KeyError"):
-                        raise KeyError(err_msg)
-                    if err_msg.startswith("ValueError"):
-                        raise ValueError(err_msg)
-                    if err_msg.startswith("TypeError"):
-                        raise TypeError(err_msg)
-                    if err_msg.startswith("RecursionError"):
-                        raise RecursionError(err_msg)
-                    if err_msg.startswith("ZeroDivisionError"):
-                        raise ZeroDivisionError(err_msg)
-                    if err_msg.startswith("AssertionError"):
-                        raise AssertionError(err_msg)
-                    raise RuntimeError(err_msg)
-
-                except Exception:
-                    p = proc_container.get("proc")
-                    if p:
-                        try:
-                            p.terminate()
-                        except Exception:
-                            pass
-                        proc_container["proc"] = None
-                    raise
-
-        _isolated_runner.__name__ = proc_container.get("target_name", "target")
-        return _isolated_runner
-
     def _resolve_callable(self, target: Any) -> Optional[Callable[..., Any]]:
-        """Resolves target callable from function/class object or wraps source string in isolated subprocess runner."""
+        """Resolves target callable from function or class object. Source strings and non-callables return None."""
         if callable(target):
             return target
-        if isinstance(target, str) and target.strip():
-            return self._create_isolated_subprocess_callable(target)
         return None
 
     def generate_break_scenarios(
@@ -742,9 +578,9 @@ while True:
             finding = BreakFinding(
                 scenario_id="target_not_executable",
                 vector=AttackVector.CHAOS_ENVIRONMENT.value,
-                hypothesis="Target must be an executable callable object or valid source code string",
+                hypothesis="Target must be an executable Python Callable object",
                 broken=True,
-                error_message="TypeError: RedTeamSwarm target is not executable (no valid callable or source code provided)",
+                error_message="TypeError: Source-code strings cannot be evaluated in-process for security reasons. Provide an executable Python Callable or use an isolated sandbox executor.",
                 severity="CRITICAL",
                 details={"target_executable": False},
             )
@@ -756,7 +592,7 @@ while True:
                 passed=False,
                 findings=[finding],
                 created_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
-                remediation_directives=["Provide an executable Python callable or valid source code string."],
+                remediation_directives=["Provide an executable Python callable or use an isolated sandbox executor."],
             )
 
         if not scenarios:

--- a/fable_v2/coder_fleet/red_team_swarm.py
+++ b/fable_v2/coder_fleet/red_team_swarm.py
@@ -222,7 +222,12 @@ class RedTeamBreakageReport:
 
 
 class RedTeamSwarm:
-    """Adversarial Red Team Swarm executing counterfactual stress probes across 5 vectors."""
+    """Adversarial Red Team Swarm executing counterfactual stress probes across 5 vectors.
+
+    RedTeamSwarm never executes source-code strings in-process. Source-code strings and
+    unexecutable targets are rejected as non-executable targets (passed=False). Dynamic source
+    execution, if required, must be provided through a separately sandboxed execution layer.
+    """
 
     def __init__(
         self,
@@ -250,8 +255,9 @@ class RedTeamSwarm:
     def _resolve_callable(self, target: Any) -> Optional[Callable[..., Any]]:
         """Resolves target callable from function or class object.
 
-        RedTeamSwarm never executes source-code strings in-process. Source-code
-        strings and non-callable targets are fail-closed as non-executable (passed=False).
+        RedTeamSwarm never executes source-code strings in-process. Source-code strings
+        are rejected as non-executable targets. Dynamic source execution, if required,
+        must be provided through a separately sandboxed execution layer.
         """
         if callable(target):
             return target

--- a/fable_v2/coder_fleet/red_team_swarm.py
+++ b/fable_v2/coder_fleet/red_team_swarm.py
@@ -277,7 +277,7 @@ class RedTeamSwarm:
 
         # Vector 1: CHAOS_ENVIRONMENT
         def _chaos_missing_path(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             # Probe with non-existent / unlinked file path
             return fn("/nonexistent/fable_chaos_probe_file.tmp")
@@ -294,7 +294,7 @@ class RedTeamSwarm:
         )
 
         def _chaos_corrupt_env(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             return fn("")
 
@@ -311,7 +311,7 @@ class RedTeamSwarm:
 
         # Vector 2: BYZANTINE_PAYLOAD
         def _byzantine_null_bytes(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             payload = "probe\x00hostile\x00injection\r\n\t"
             return fn(payload)
@@ -328,7 +328,7 @@ class RedTeamSwarm:
         )
 
         def _byzantine_deep_nesting(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             # 60 levels of nested dictionaries
             nested: dict[str, Any] = {"leaf": 42}
@@ -348,7 +348,7 @@ class RedTeamSwarm:
         )
 
         def _byzantine_type_confusion(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             return fn(None)
 
@@ -364,7 +364,7 @@ class RedTeamSwarm:
         )
 
         def _byzantine_extreme_numbers(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             # Nan, Inf, negative zero, huge int
             return fn(float("nan"))
@@ -382,7 +382,7 @@ class RedTeamSwarm:
 
         # Vector 3: CONCURRENCY_RACE
         def _concurrency_multithreaded_burst(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             errors: list[str] = []
             threads: list[threading.Thread] = []
@@ -428,7 +428,7 @@ class RedTeamSwarm:
 
         # Vector 4: RESOURCE_EXHAUSTION
         def _resource_massive_payload(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             massive_str = "A" * 150_000
             return fn(massive_str)
@@ -445,7 +445,7 @@ class RedTeamSwarm:
         )
 
         def _resource_rapid_churn(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             sig = inspect.signature(fn)
             for _ in range(100):
@@ -468,7 +468,7 @@ class RedTeamSwarm:
 
         # Vector 5: STATE_INVARIANT
         def _state_invariant_idempotency(fn: Optional[Callable[..., Any]] = None) -> Any:
-            if not fn:
+            if fn is None:
                 raise TypeError("RedTeamSwarm target callable is missing or not executable")
             sig = inspect.signature(fn)
             if len(sig.parameters) == 0:
@@ -510,7 +510,7 @@ class RedTeamSwarm:
                     v = AttackVector.CHAOS_ENVIRONMENT
 
                 def _custom_attack_fn(fn: Optional[Callable[..., Any]] = None, h_text: str = hyp_clean) -> Any:
-                    if not fn:
+                    if fn is None:
                         raise TypeError("RedTeamSwarm target callable is missing or not executable")
                     sig = inspect.signature(fn)
                     if len(sig.parameters) == 0:
@@ -817,8 +817,8 @@ class RedTeamSwarm:
                     vec = AttackVector.CHAOS_ENVIRONMENT
 
                 def _repro_probe(fn: Optional[Callable[..., Any]] = None, finding: BreakFinding = f) -> Any:
-                    if not fn:
-                        return True
+                    if fn is None:
+                        raise TypeError("RedTeamSwarm target callable is missing or not executable")
                     sig = inspect.signature(fn)
                     if len(sig.parameters) == 0:
                         return fn()

--- a/fable_v2/coder_fleet/red_team_swarm.py
+++ b/fable_v2/coder_fleet/red_team_swarm.py
@@ -248,7 +248,11 @@ class RedTeamSwarm:
                     self.plasticity_engine = None
 
     def _resolve_callable(self, target: Any) -> Optional[Callable[..., Any]]:
-        """Resolves target callable from function or class object. Source strings and non-callables return None."""
+        """Resolves target callable from function or class object.
+
+        RedTeamSwarm never executes source-code strings in-process. Source-code
+        strings and non-callable targets are fail-closed as non-executable (passed=False).
+        """
         if callable(target):
             return target
         return None

--- a/fable_v2/coder_fleet/red_team_swarm.py
+++ b/fable_v2/coder_fleet/red_team_swarm.py
@@ -8,11 +8,14 @@ Production-grade Red Team Swarm engine providing:
 """
 from __future__ import annotations
 
+import atexit
 import datetime
 import inspect
 import json
 import os
+import subprocess
 import sys
+import tempfile
 import threading
 import time
 import traceback
@@ -244,10 +247,174 @@ class RedTeamSwarm:
                 except Exception:
                     self.plasticity_engine = None
 
+    def _create_isolated_subprocess_callable(self, code: str) -> Callable[..., Any]:
+        """Wraps Python code string in an isolated subprocess executor (no in-process exec)."""
+        proc_lock = threading.Lock()
+        proc_container: dict[str, Any] = {"proc": None, "target_name": "target"}
+
+        def _start_proc() -> None:
+            driver = f"""import json
+import sys
+import inspect
+import traceback
+
+code_str = {repr(code)}
+
+scope = {{}}
+try:
+    exec(code_str, scope, scope)
+except Exception as e:
+    sys.stderr.write(f"CompilationError: {{type(e).__name__}}: {{e}}\\n{{traceback.format_exc()}}\\n")
+    sys.exit(1)
+
+funcs = [v for k, v in scope.items() if callable(v) and not k.startswith("_") and not isinstance(v, type)]
+classes = [v for k, v in scope.items() if isinstance(v, type) and not k.startswith("_")]
+target = funcs[-1] if funcs else (classes[-1] if classes else None)
+
+if target is None:
+    sys.stderr.write("TypeError: No top-level function or class found in code snippet\\n")
+    sys.exit(1)
+
+print("__TARGET_NAME__:" + getattr(target, "__name__", "target"))
+sys.stdout.flush()
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    try:
+        req = json.loads(line)
+        payload = req.get("payload")
+
+        try:
+            sig = inspect.signature(target)
+            has_params = len(sig.parameters) > 0
+        except Exception:
+            has_params = True
+
+        if has_params:
+            res = target(payload)
+        else:
+            res = target()
+        print(json.dumps({{"success": True, "result": str(res)}}))
+        sys.stdout.flush()
+    except Exception as e:
+        err_msg = f"{{type(e).__name__}}: {{e}}"
+        print(json.dumps({{"success": False, "error": err_msg, "traceback": traceback.format_exc()}}))
+        sys.stdout.flush()
+"""
+            temp_fd, temp_path = tempfile.mkstemp(suffix=".py", text=True)
+            try:
+                with os.fdopen(temp_fd, "w", encoding="utf-8") as f:
+                    f.write(driver)
+
+                proc = subprocess.Popen(
+                    [sys.executable, temp_path],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    bufsize=1,
+                )
+                line = proc.stdout.readline() if proc.stdout else ""
+                if line.startswith("__TARGET_NAME__:"):
+                    proc_container["target_name"] = line.split(":", 1)[1].strip()
+                    proc_container["proc"] = proc
+                    atexit.register(lambda p=proc: p.poll() is None and p.terminate())
+                else:
+                    stderr = proc.stderr.read() if proc.stderr else ""
+                    proc.terminate()
+                    proc_container["proc"] = None
+                    raise RuntimeError(f"Subprocess initialization failed: {stderr or line}")
+            finally:
+                if os.path.exists(temp_path):
+                    try:
+                        os.remove(temp_path)
+                    except OSError:
+                        pass
+
+        def _isolated_runner(payload: Any = None) -> Any:
+            with proc_lock:
+                proc = proc_container.get("proc")
+                if not proc or proc.poll() is not None:
+                    _start_proc()
+                    proc = proc_container.get("proc")
+
+                try:
+                    try:
+                        payload_json = json.dumps(payload)
+                    except Exception:
+                        payload_json = json.dumps(str(payload))
+
+                    req_str = json.dumps({"payload_raw": payload_json, "payload": payload}) + "\n"
+                    assert proc and proc.stdin and proc.stdout
+                    proc.stdin.write(req_str)
+                    proc.stdin.flush()
+
+                    resp_line = proc.stdout.readline()
+                    if not resp_line:
+                        stderr = proc.stderr.read() if proc.stderr else ""
+                        proc_container["proc"] = None
+                        if "MemoryError" in stderr:
+                            raise MemoryError(stderr)
+                        if "AttributeError" in stderr:
+                            raise AttributeError(stderr)
+                        if "KeyError" in stderr:
+                            raise KeyError(stderr)
+                        if "ValueError" in stderr:
+                            raise ValueError(stderr)
+                        if "TypeError" in stderr:
+                            raise TypeError(stderr)
+                        if "RecursionError" in stderr:
+                            raise RecursionError(stderr)
+                        if "ZeroDivisionError" in stderr:
+                            raise ZeroDivisionError(stderr)
+                        if "AssertionError" in stderr:
+                            raise AssertionError(stderr)
+                        raise RuntimeError(stderr or "Subprocess exited unexpectedly")
+
+                    data = json.loads(resp_line)
+                    if data.get("success"):
+                        return data.get("result")
+
+                    err_msg = data.get("error", "Error in subprocess")
+                    if err_msg.startswith("MemoryError"):
+                        raise MemoryError(err_msg)
+                    if err_msg.startswith("AttributeError"):
+                        raise AttributeError(err_msg)
+                    if err_msg.startswith("KeyError"):
+                        raise KeyError(err_msg)
+                    if err_msg.startswith("ValueError"):
+                        raise ValueError(err_msg)
+                    if err_msg.startswith("TypeError"):
+                        raise TypeError(err_msg)
+                    if err_msg.startswith("RecursionError"):
+                        raise RecursionError(err_msg)
+                    if err_msg.startswith("ZeroDivisionError"):
+                        raise ZeroDivisionError(err_msg)
+                    if err_msg.startswith("AssertionError"):
+                        raise AssertionError(err_msg)
+                    raise RuntimeError(err_msg)
+
+                except Exception:
+                    p = proc_container.get("proc")
+                    if p:
+                        try:
+                            p.terminate()
+                        except Exception:
+                            pass
+                        proc_container["proc"] = None
+                    raise
+
+        _isolated_runner.__name__ = proc_container.get("target_name", "target")
+        return _isolated_runner
+
     def _resolve_callable(self, target: Any) -> Optional[Callable[..., Any]]:
-        """Resolves target callable from function or class object. String targets are returned as None."""
+        """Resolves target callable from function/class object or wraps source string in isolated subprocess runner."""
         if callable(target):
             return target
+        if isinstance(target, str) and target.strip():
+            return self._create_isolated_subprocess_callable(target)
         return None
 
     def generate_break_scenarios(
@@ -265,7 +432,7 @@ class RedTeamSwarm:
         # Vector 1: CHAOS_ENVIRONMENT
         def _chaos_missing_path(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             # Probe with non-existent / unlinked file path
             return fn("/nonexistent/fable_chaos_probe_file.tmp")
 
@@ -282,7 +449,7 @@ class RedTeamSwarm:
 
         def _chaos_corrupt_env(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             return fn("")
 
         scenarios.append(
@@ -299,7 +466,7 @@ class RedTeamSwarm:
         # Vector 2: BYZANTINE_PAYLOAD
         def _byzantine_null_bytes(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             payload = "probe\x00hostile\x00injection\r\n\t"
             return fn(payload)
 
@@ -316,7 +483,7 @@ class RedTeamSwarm:
 
         def _byzantine_deep_nesting(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             # 60 levels of nested dictionaries
             nested: dict[str, Any] = {"leaf": 42}
             for _ in range(60):
@@ -336,7 +503,7 @@ class RedTeamSwarm:
 
         def _byzantine_type_confusion(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             return fn(None)
 
         scenarios.append(
@@ -352,7 +519,7 @@ class RedTeamSwarm:
 
         def _byzantine_extreme_numbers(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             # Nan, Inf, negative zero, huge int
             return fn(float("nan"))
 
@@ -370,7 +537,7 @@ class RedTeamSwarm:
         # Vector 3: CONCURRENCY_RACE
         def _concurrency_multithreaded_burst(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             errors: list[str] = []
             threads: list[threading.Thread] = []
             try:
@@ -416,7 +583,7 @@ class RedTeamSwarm:
         # Vector 4: RESOURCE_EXHAUSTION
         def _resource_massive_payload(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             massive_str = "A" * 150_000
             return fn(massive_str)
 
@@ -433,7 +600,7 @@ class RedTeamSwarm:
 
         def _resource_rapid_churn(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             sig = inspect.signature(fn)
             for _ in range(100):
                 if len(sig.parameters) == 0:
@@ -456,7 +623,7 @@ class RedTeamSwarm:
         # Vector 5: STATE_INVARIANT
         def _state_invariant_idempotency(fn: Optional[Callable[..., Any]] = None) -> Any:
             if not fn:
-                return True
+                raise TypeError("RedTeamSwarm target callable is missing or not executable")
             sig = inspect.signature(fn)
             if len(sig.parameters) == 0:
                 res1 = fn()
@@ -498,7 +665,7 @@ class RedTeamSwarm:
 
                 def _custom_attack_fn(fn: Optional[Callable[..., Any]] = None, h_text: str = hyp_clean) -> Any:
                     if not fn:
-                        return True
+                        raise TypeError("RedTeamSwarm target callable is missing or not executable")
                     sig = inspect.signature(fn)
                     if len(sig.parameters) == 0:
                         return fn()
@@ -569,6 +736,28 @@ class RedTeamSwarm:
         """
         callable_fn = self._resolve_callable(target_callable)
         actual_name = target_name or getattr(callable_fn, "__name__", "target")
+
+        if callable_fn is None:
+            report_id = f"redteam_{int(time.time())}_{uuid.uuid4().hex[:6]}"
+            finding = BreakFinding(
+                scenario_id="target_not_executable",
+                vector=AttackVector.CHAOS_ENVIRONMENT.value,
+                hypothesis="Target must be an executable callable object or valid source code string",
+                broken=True,
+                error_message="TypeError: RedTeamSwarm target is not executable (no valid callable or source code provided)",
+                severity="CRITICAL",
+                details={"target_executable": False},
+            )
+            return RedTeamBreakageReport(
+                report_id=report_id,
+                target_name=actual_name,
+                total_probes=1,
+                broken_count=1,
+                passed=False,
+                findings=[finding],
+                created_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                remediation_directives=["Provide an executable Python callable or valid source code string."],
+            )
 
         if not scenarios:
             scenarios = self.generate_break_scenarios(target_name=actual_name)

--- a/skills/fable-mode/cortex/synaptic_matrix.json
+++ b/skills/fable-mode/cortex/synaptic_matrix.json
@@ -1,4 +1,9 @@
 {
+  "diagnostics": {
+    "red_team_swarm": 0.2231,
+    "system": 0.2588,
+    "test_harness": 0.2256
+  },
   "mutation": {
     "property_oracle": 0.2229,
     "red_team_swarm": 0.7737,
@@ -15,10 +20,12 @@
     "test_distributed_raft": 0.95
   },
   "red_team_swarm": {
+    "diagnostics": 0.2231,
     "mutation": 0.7737,
     "property_oracle": 0.218,
     "security": 0.7082,
-    "test_harness": 0.7523
+    "system": 0.2609,
+    "test_harness": 0.8306
   },
   "security": {
     "mutation": 0.6983,
@@ -26,13 +33,20 @@
     "red_team_swarm": 0.7082,
     "test_harness": 0.6812
   },
+  "system": {
+    "diagnostics": 0.2588,
+    "red_team_swarm": 0.2609,
+    "test_harness": 0.263
+  },
   "test_distributed_raft": {
     "quorum": 0.95
   },
   "test_harness": {
+    "diagnostics": 0.2256,
     "mutation": 0.74,
     "property_oracle": 0.2205,
-    "red_team_swarm": 0.7523,
-    "security": 0.6812
+    "red_team_swarm": 0.8306,
+    "security": 0.6812,
+    "system": 0.263
   }
 }

--- a/skills/fable-mode/cortex/synaptic_matrix.json
+++ b/skills/fable-mode/cortex/synaptic_matrix.json
@@ -1,34 +1,34 @@
 {
   "diagnostics": {
-    "red_team_swarm": 0.2962,
-    "system": 0.3176,
-    "test_harness": 0.3012
+    "red_team_swarm": 0.3693,
+    "system": 0.3764,
+    "test_harness": 0.3768
   },
   "mutation": {
-    "property_oracle": 0.2958,
-    "red_team_swarm": 0.8493,
+    "property_oracle": 0.3687,
+    "red_team_swarm": 0.9249,
     "security": 0.6983,
-    "target": 0.272,
-    "test_harness": 0.8183
+    "target": 0.344,
+    "test_harness": 0.8966
   },
   "property_oracle": {
-    "mutation": 0.2958,
-    "red_team_swarm": 0.286,
+    "mutation": 0.3687,
+    "red_team_swarm": 0.354,
     "security": 0.2648,
-    "target": 0.2648,
-    "test_harness": 0.291
+    "target": 0.3296,
+    "test_harness": 0.3615
   },
   "quorum": {
     "test_distributed_raft": 0.95
   },
   "red_team_swarm": {
-    "diagnostics": 0.2962,
-    "mutation": 0.8493,
-    "property_oracle": 0.286,
+    "diagnostics": 0.3693,
+    "mutation": 0.9249,
+    "property_oracle": 0.354,
     "security": 0.7082,
-    "system": 0.3218,
-    "target": 0.2672,
-    "test_harness": 0.982
+    "system": 0.3827,
+    "target": 0.3344,
+    "test_harness": 1.0
   },
   "security": {
     "mutation": 0.6983,
@@ -37,26 +37,26 @@
     "test_harness": 0.6812
   },
   "system": {
-    "diagnostics": 0.3176,
-    "red_team_swarm": 0.3218,
-    "test_harness": 0.326
+    "diagnostics": 0.3764,
+    "red_team_swarm": 0.3827,
+    "test_harness": 0.389
   },
   "target": {
-    "mutation": 0.272,
-    "property_oracle": 0.2648,
-    "red_team_swarm": 0.2672,
-    "test_harness": 0.2696
+    "mutation": 0.344,
+    "property_oracle": 0.3296,
+    "red_team_swarm": 0.3344,
+    "test_harness": 0.3392
   },
   "test_distributed_raft": {
     "quorum": 0.95
   },
   "test_harness": {
-    "diagnostics": 0.3012,
-    "mutation": 0.8183,
-    "property_oracle": 0.291,
-    "red_team_swarm": 0.982,
+    "diagnostics": 0.3768,
+    "mutation": 0.8966,
+    "property_oracle": 0.3615,
+    "red_team_swarm": 1.0,
     "security": 0.6812,
-    "system": 0.326,
-    "target": 0.2696
+    "system": 0.389,
+    "target": 0.3392
   }
 }

--- a/skills/fable-mode/cortex/synaptic_matrix.json
+++ b/skills/fable-mode/cortex/synaptic_matrix.json
@@ -1,31 +1,34 @@
 {
   "diagnostics": {
-    "red_team_swarm": 0.2231,
-    "system": 0.2588,
-    "test_harness": 0.2256
+    "red_team_swarm": 0.2962,
+    "system": 0.3176,
+    "test_harness": 0.3012
   },
   "mutation": {
-    "property_oracle": 0.2229,
-    "red_team_swarm": 0.7737,
+    "property_oracle": 0.2958,
+    "red_team_swarm": 0.8493,
     "security": 0.6983,
-    "test_harness": 0.74
+    "target": 0.272,
+    "test_harness": 0.8183
   },
   "property_oracle": {
-    "mutation": 0.2229,
-    "red_team_swarm": 0.218,
+    "mutation": 0.2958,
+    "red_team_swarm": 0.286,
     "security": 0.2648,
-    "test_harness": 0.2205
+    "target": 0.2648,
+    "test_harness": 0.291
   },
   "quorum": {
     "test_distributed_raft": 0.95
   },
   "red_team_swarm": {
-    "diagnostics": 0.2231,
-    "mutation": 0.7737,
-    "property_oracle": 0.218,
+    "diagnostics": 0.2962,
+    "mutation": 0.8493,
+    "property_oracle": 0.286,
     "security": 0.7082,
-    "system": 0.2609,
-    "test_harness": 0.8306
+    "system": 0.3218,
+    "target": 0.2672,
+    "test_harness": 0.982
   },
   "security": {
     "mutation": 0.6983,
@@ -34,19 +37,26 @@
     "test_harness": 0.6812
   },
   "system": {
-    "diagnostics": 0.2588,
-    "red_team_swarm": 0.2609,
-    "test_harness": 0.263
+    "diagnostics": 0.3176,
+    "red_team_swarm": 0.3218,
+    "test_harness": 0.326
+  },
+  "target": {
+    "mutation": 0.272,
+    "property_oracle": 0.2648,
+    "red_team_swarm": 0.2672,
+    "test_harness": 0.2696
   },
   "test_distributed_raft": {
     "quorum": 0.95
   },
   "test_harness": {
-    "diagnostics": 0.2256,
-    "mutation": 0.74,
-    "property_oracle": 0.2205,
-    "red_team_swarm": 0.8306,
+    "diagnostics": 0.3012,
+    "mutation": 0.8183,
+    "property_oracle": 0.291,
+    "red_team_swarm": 0.982,
     "security": 0.6812,
-    "system": 0.263
+    "system": 0.326,
+    "target": 0.2696
   }
 }

--- a/skills/fable-mode/cortex/system.md
+++ b/skills/fable-mode/cortex/system.md
@@ -1,0 +1,44 @@
+---
+{
+  "name": "system",
+  "description": "Custom cortical lobe for system development and specialized heuristics",
+  "domain": "system",
+  "activation_count": 1,
+  "synaptic_weights": {
+    "test_harness": 0.363,
+    "red_team_swarm": 0.3609,
+    "diagnostics": 0.3588
+  },
+  "antibodies": [],
+  "specialized_heuristics": [],
+  "last_consolidated_at": "2026-09-10T15:18:14.540141+00:00"
+}
+---
+
+# Cortical Lobe: `system`
+
+> [!NOTE]
+> Custom cortical lobe for system development and specialized heuristics
+> Activation count: 1.
+
+## Metadata & Telemetry
+- **Name**: `system`
+- **Description**: Custom cortical lobe for system development and specialized heuristics
+- **Domain**: `system`
+- **Activation Count**: `1`
+- **Total Antibodies**: `0`
+- **Specialized Heuristics**: `0`
+- **Last Consolidated**: `2026-09-10T15:18:14.540141+00:00`
+
+## Specialized Domain Heuristics
+- *(No domain heuristics registered yet)*
+
+## Synaptic Tool & Node Weights (Hebbian Association)
+| Synaptic Node / Tool | Weight ($W_{ij}$) | Strength |
+| :--- | :--- | :--- |
+| `test_harness` | `0.3630` | ⚪ Latent |
+| `red_team_swarm` | `0.3609` | ⚪ Latent |
+| `diagnostics` | `0.3588` | ⚪ Latent |
+
+## Immunological Antibodies (Red-Team Scars)
+- *(Zero known fatal vulnerabilities cataloged)*

--- a/skills/fable-mode/cortex/system.md
+++ b/skills/fable-mode/cortex/system.md
@@ -3,15 +3,15 @@
   "name": "system",
   "description": "Custom cortical lobe for system development and specialized heuristics",
   "domain": "system",
-  "activation_count": 2,
+  "activation_count": 3,
   "synaptic_weights": {
-    "test_harness": 0.426,
-    "red_team_swarm": 0.4218,
-    "diagnostics": 0.4176
+    "test_harness": 0.489,
+    "red_team_swarm": 0.4827,
+    "diagnostics": 0.4764
   },
   "antibodies": [],
   "specialized_heuristics": [],
-  "last_consolidated_at": "2026-09-10T16:10:33.467318+00:00"
+  "last_consolidated_at": "2026-09-10T16:23:18.184792+00:00"
 }
 ---
 
@@ -19,16 +19,16 @@
 
 > [!NOTE]
 > Custom cortical lobe for system development and specialized heuristics
-> Activation count: 2.
+> Activation count: 3.
 
 ## Metadata & Telemetry
 - **Name**: `system`
 - **Description**: Custom cortical lobe for system development and specialized heuristics
 - **Domain**: `system`
-- **Activation Count**: `2`
+- **Activation Count**: `3`
 - **Total Antibodies**: `0`
 - **Specialized Heuristics**: `0`
-- **Last Consolidated**: `2026-09-10T16:10:33.467318+00:00`
+- **Last Consolidated**: `2026-09-10T16:23:18.184792+00:00`
 
 ## Specialized Domain Heuristics
 - *(No domain heuristics registered yet)*
@@ -36,9 +36,9 @@
 ## Synaptic Tool & Node Weights (Hebbian Association)
 | Synaptic Node / Tool | Weight ($W_{ij}$) | Strength |
 | :--- | :--- | :--- |
-| `test_harness` | `0.4260` | 🟡 Moderate |
-| `red_team_swarm` | `0.4218` | 🟡 Moderate |
-| `diagnostics` | `0.4176` | 🟡 Moderate |
+| `test_harness` | `0.4890` | 🟡 Moderate |
+| `red_team_swarm` | `0.4827` | 🟡 Moderate |
+| `diagnostics` | `0.4764` | 🟡 Moderate |
 
 ## Immunological Antibodies (Red-Team Scars)
 - *(Zero known fatal vulnerabilities cataloged)*

--- a/skills/fable-mode/cortex/system.md
+++ b/skills/fable-mode/cortex/system.md
@@ -3,15 +3,15 @@
   "name": "system",
   "description": "Custom cortical lobe for system development and specialized heuristics",
   "domain": "system",
-  "activation_count": 1,
+  "activation_count": 2,
   "synaptic_weights": {
-    "test_harness": 0.363,
-    "red_team_swarm": 0.3609,
-    "diagnostics": 0.3588
+    "test_harness": 0.426,
+    "red_team_swarm": 0.4218,
+    "diagnostics": 0.4176
   },
   "antibodies": [],
   "specialized_heuristics": [],
-  "last_consolidated_at": "2026-09-10T15:18:14.540141+00:00"
+  "last_consolidated_at": "2026-09-10T16:10:33.467318+00:00"
 }
 ---
 
@@ -19,16 +19,16 @@
 
 > [!NOTE]
 > Custom cortical lobe for system development and specialized heuristics
-> Activation count: 1.
+> Activation count: 2.
 
 ## Metadata & Telemetry
 - **Name**: `system`
 - **Description**: Custom cortical lobe for system development and specialized heuristics
 - **Domain**: `system`
-- **Activation Count**: `1`
+- **Activation Count**: `2`
 - **Total Antibodies**: `0`
 - **Specialized Heuristics**: `0`
-- **Last Consolidated**: `2026-09-10T15:18:14.540141+00:00`
+- **Last Consolidated**: `2026-09-10T16:10:33.467318+00:00`
 
 ## Specialized Domain Heuristics
 - *(No domain heuristics registered yet)*
@@ -36,9 +36,9 @@
 ## Synaptic Tool & Node Weights (Hebbian Association)
 | Synaptic Node / Tool | Weight ($W_{ij}$) | Strength |
 | :--- | :--- | :--- |
-| `test_harness` | `0.3630` | ⚪ Latent |
-| `red_team_swarm` | `0.3609` | ⚪ Latent |
-| `diagnostics` | `0.3588` | ⚪ Latent |
+| `test_harness` | `0.4260` | 🟡 Moderate |
+| `red_team_swarm` | `0.4218` | 🟡 Moderate |
+| `diagnostics` | `0.4176` | 🟡 Moderate |
 
 ## Immunological Antibodies (Red-Team Scars)
 - *(Zero known fatal vulnerabilities cataloged)*

--- a/skills/fable-mode/cortex/target.md
+++ b/skills/fable-mode/cortex/target.md
@@ -1,0 +1,66 @@
+---
+{
+  "name": "target",
+  "description": "Custom cortical lobe for target development and specialized heuristics",
+  "domain": "target",
+  "activation_count": 1,
+  "synaptic_weights": {
+    "mutation": 0.372,
+    "test_harness": 0.3696,
+    "red_team_swarm": 0.3672,
+    "property_oracle": 0.3648
+  },
+  "antibodies": [
+    {
+      "antibody_id": "ab_target_target_chaos_01_missing_path",
+      "domain": "target",
+      "trigger_condition": "Hypothesis",
+      "lethal_anti_pattern": "Unchecked execution failure under adversarial pressure",
+      "prescribed_defense": "Enforce strict precondition verification and atomic isolation.",
+      "severity": "MEDIUM",
+      "source_task_id": "rep_prior_falsey",
+      "created_at": "2026-09-10T16:10:33.481288+00:00",
+      "verified_counterfactual": "Counterfactual validation against vector: chaos_environment"
+    }
+  ],
+  "specialized_heuristics": [
+    "Defense against [Hypothesis]: Hardened implementation"
+  ],
+  "last_consolidated_at": "2026-09-10T16:10:33.481311+00:00"
+}
+---
+
+# Cortical Lobe: `target`
+
+> [!NOTE]
+> Custom cortical lobe for target development and specialized heuristics
+> Activation count: 1.
+
+## Metadata & Telemetry
+- **Name**: `target`
+- **Description**: Custom cortical lobe for target development and specialized heuristics
+- **Domain**: `target`
+- **Activation Count**: `1`
+- **Total Antibodies**: `1`
+- **Specialized Heuristics**: `1`
+- **Last Consolidated**: `2026-09-10T16:10:33.481311+00:00`
+
+## Specialized Domain Heuristics
+1. Defense against [Hypothesis]: Hardened implementation
+
+## Synaptic Tool & Node Weights (Hebbian Association)
+| Synaptic Node / Tool | Weight ($W_{ij}$) | Strength |
+| :--- | :--- | :--- |
+| `mutation` | `0.3720` | ⚪ Latent |
+| `test_harness` | `0.3696` | ⚪ Latent |
+| `red_team_swarm` | `0.3672` | ⚪ Latent |
+| `property_oracle` | `0.3648` | ⚪ Latent |
+
+## Immunological Antibodies (Red-Team Scars)
+#### Antibody `ab_target_target_chaos_01_missing_path` [MEDIUM]
+- **Domain**: `target`
+- **Trigger Condition**: Hypothesis
+- **Lethal Anti-Pattern**: Unchecked execution failure under adversarial pressure
+- **Prescribed Defense**: Enforce strict precondition verification and atomic isolation.
+- **Verified Counterfactual**: `Counterfactual validation against vector: chaos_environment`
+- **Source Task ID**: `rep_prior_falsey`

--- a/skills/fable-mode/cortex/target.md
+++ b/skills/fable-mode/cortex/target.md
@@ -3,12 +3,12 @@
   "name": "target",
   "description": "Custom cortical lobe for target development and specialized heuristics",
   "domain": "target",
-  "activation_count": 1,
+  "activation_count": 2,
   "synaptic_weights": {
-    "mutation": 0.372,
-    "test_harness": 0.3696,
-    "red_team_swarm": 0.3672,
-    "property_oracle": 0.3648
+    "mutation": 0.444,
+    "test_harness": 0.4392,
+    "red_team_swarm": 0.4344,
+    "property_oracle": 0.4296
   },
   "antibodies": [
     {
@@ -26,7 +26,7 @@
   "specialized_heuristics": [
     "Defense against [Hypothesis]: Hardened implementation"
   ],
-  "last_consolidated_at": "2026-09-10T16:10:33.481311+00:00"
+  "last_consolidated_at": "2026-09-10T16:23:18.199648+00:00"
 }
 ---
 
@@ -34,16 +34,16 @@
 
 > [!NOTE]
 > Custom cortical lobe for target development and specialized heuristics
-> Activation count: 1.
+> Activation count: 2.
 
 ## Metadata & Telemetry
 - **Name**: `target`
 - **Description**: Custom cortical lobe for target development and specialized heuristics
 - **Domain**: `target`
-- **Activation Count**: `1`
+- **Activation Count**: `2`
 - **Total Antibodies**: `1`
 - **Specialized Heuristics**: `1`
-- **Last Consolidated**: `2026-09-10T16:10:33.481311+00:00`
+- **Last Consolidated**: `2026-09-10T16:23:18.199648+00:00`
 
 ## Specialized Domain Heuristics
 1. Defense against [Hypothesis]: Hardened implementation
@@ -51,10 +51,10 @@
 ## Synaptic Tool & Node Weights (Hebbian Association)
 | Synaptic Node / Tool | Weight ($W_{ij}$) | Strength |
 | :--- | :--- | :--- |
-| `mutation` | `0.3720` | ⚪ Latent |
-| `test_harness` | `0.3696` | ⚪ Latent |
-| `red_team_swarm` | `0.3672` | ⚪ Latent |
-| `property_oracle` | `0.3648` | ⚪ Latent |
+| `mutation` | `0.4440` | 🟡 Moderate |
+| `test_harness` | `0.4392` | 🟡 Moderate |
+| `red_team_swarm` | `0.4344` | 🟡 Moderate |
+| `property_oracle` | `0.4296` | 🟡 Moderate |
 
 ## Immunological Antibodies (Red-Team Scars)
 #### Antibody `ab_target_target_chaos_01_missing_path` [MEDIUM]

--- a/tests/test_fsm_redteam_evolution.py
+++ b/tests/test_fsm_redteam_evolution.py
@@ -257,7 +257,9 @@ class TestFSMRedTeamEvolution(unittest.TestCase):
                 }
             ]
         }
-        flawed_code = "def process(x):\n    raise MemoryError('Still leaking')"
+        def flawed_code(x=None):
+            raise MemoryError('Still leaking')
+
         resp_flawed = handle_fable_session({
             "action": "verify_red_team_remediation",
             "session_name": session_name,
@@ -269,7 +271,9 @@ class TestFSMRedTeamEvolution(unittest.TestCase):
         self.assertEqual(session.current_state, SessionState.REMEDIATION_REQUIRED)
 
         # 3. Subagent submits fully fixed code that survives the prior breaking probe
-        fixed_code = "def process(x):\n    return 'clean'"
+        def fixed_code(x=None):
+            return 'clean'
+
         resp_fixed = handle_fable_session({
             "action": "verify_red_team_remediation",
             "session_name": session_name,

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -136,6 +136,19 @@ class TestRedTeamSwarmSecurityBoundary(unittest.TestCase):
         self.assertTrue(report.passed)
         self.assertEqual(report.broken_count, 0)
 
+    def test_false_bool_callable_object_succeeds(self) -> None:
+        class FalseCallable:
+            def __bool__(self) -> bool:
+                return False
+
+            def __call__(self, x: Any = None) -> str:
+                return "ok"
+
+        false_callable = FalseCallable()
+        report = self.swarm.execute_swarm_attack(false_callable)
+        self.assertTrue(report.passed)
+        self.assertEqual(report.broken_count, 0)
+
 
 class TestReportFormattingAndSerialization(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -118,35 +118,23 @@ class TestRedTeamSwarmSecurityBoundary(unittest.TestCase):
         self.assertFalse(report.passed)
         self.assertEqual(report.broken_count, 1)
         self.assertEqual(report.findings[0].scenario_id, "target_not_executable")
+        self.assertFalse(report.findings[0].details.get("target_executable", True))
         self.assertIn("TypeError", report.findings[0].error_message or "")
 
-    def test_source_string_with_flaw_fails_closed(self) -> None:
-        code_snippet = (
-            "def fragile_fn(x=None):\n"
-            "    if x is None:\n"
-            "        raise AttributeError('NoneType object has no attribute')\n"
-            "    return 'ok'\n"
-        )
+    def test_source_string_target_fails_closed(self) -> None:
+        code_snippet = "def safe_fn(x=None):\n    return 'ok'\n"
         report = self.swarm.execute_swarm_attack(code_snippet)
         self.assertFalse(report.passed)
-        self.assertGreater(report.broken_count, 0)
+        self.assertEqual(report.broken_count, 1)
+        self.assertFalse(report.findings[0].details.get("target_executable", True))
 
-    def test_source_string_safe_passes(self) -> None:
-        code_snippet = (
-            "def safe_fn(x=None):\n"
-            "    if x is None:\n"
-            "        return 'ok'\n"
-            "    return 'ok'\n"
-        )
-        report = self.swarm.execute_swarm_attack(code_snippet)
+    def test_callable_object_succeeds(self) -> None:
+        def safe_fn(x=None):
+            return "ok"
+
+        report = self.swarm.execute_swarm_attack(safe_fn)
         self.assertTrue(report.passed)
         self.assertEqual(report.broken_count, 0)
-
-    def test_source_string_syntax_error_fails_closed(self) -> None:
-        code_snippet = "def bad_syntax(%%%"
-        report = self.swarm.execute_swarm_attack(code_snippet)
-        self.assertFalse(report.passed)
-        self.assertGreater(report.broken_count, 0)
 
 
 class TestReportFormattingAndSerialization(unittest.TestCase):
@@ -354,15 +342,27 @@ class TestCoderFleetDispatcherRedTeamActions(unittest.TestCase):
         self.assertGreater(len(scenarios), 0)
 
     def test_dispatch_red_team_full_review_cycle(self) -> None:
-        code_snippet = "def safe_fn(x=None):\n    return 'safe'\n"
+        def safe_fn(x=None):
+            return "safe"
+
         res = self.dispatcher.dispatch(
             "red_team_full_review_cycle",
-            {"target_callable": code_snippet, "target_name": "safe_fn"},
+            {"target_callable": safe_fn, "target_name": "safe_fn"},
         )
         self.assertTrue(res["success"])
         report = res["result"]
         self.assertTrue(isinstance(report, RedTeamBreakageReport))
         self.assertTrue(report.passed)
+
+        # Source code strings produce fail-closed breakage reports
+        res_str = self.dispatcher.dispatch(
+            "red_team_full_review_cycle",
+            {"target_callable": "def safe_fn(x=None):\n    return 'safe'\n", "target_name": "safe_fn"},
+        )
+        self.assertTrue(res_str["success"])
+        report_str = res_str["result"]
+        self.assertFalse(report_str.passed)
+        self.assertEqual(report_str.broken_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -323,23 +323,39 @@ class TestPingPongRemediationCycle(unittest.TestCase):
 
 
 class TestPublicActionHandlers(unittest.TestCase):
-    def test_handle_red_team_code_review_rejects_source_string(self) -> None:
+    def test_handle_red_team_code_review_rejects_source_string_without_mutation(self) -> None:
         from fable_engine.actions.fleet import _handle_red_team_code_review
+        from fable_engine.session import FableSession, ACTIVE_SESSIONS
+        session = FableSession(session_name="test_no_mutate_01", objective="Test no mutation", time_budget_minutes=5.0)
+        ACTIVE_SESSIONS["test_no_mutate_01"] = session
+        initial_reports_len = len(session.breakage_reports)
+        initial_state = session.current_state
+
         resp = _handle_red_team_code_review({
             "action": "red_team_code_review",
-            "session_name": "test_handler_session",
+            "session_name": "test_no_mutate_01",
             "target_code": "def process(): pass",
         })
         self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
+        self.assertEqual(len(session.breakage_reports), initial_reports_len)
+        self.assertEqual(session.current_state, initial_state)
 
-    def test_handle_verify_red_team_remediation_rejects_source_string(self) -> None:
+    def test_handle_verify_red_team_remediation_rejects_source_string_without_mutation(self) -> None:
         from fable_engine.actions.fleet import _handle_verify_red_team_remediation
+        from fable_engine.session import FableSession, ACTIVE_SESSIONS
+        session = FableSession(session_name="test_no_mutate_02", objective="Test no mutation", time_budget_minutes=5.0)
+        ACTIVE_SESSIONS["test_no_mutate_02"] = session
+        initial_reports_len = len(session.breakage_reports)
+        initial_state = session.current_state
+
         resp = _handle_verify_red_team_remediation({
             "action": "verify_red_team_remediation",
-            "session_name": "test_handler_session",
+            "session_name": "test_no_mutate_02",
             "remediated_code": "def process(): pass",
         })
         self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
+        self.assertEqual(len(session.breakage_reports), initial_reports_len)
+        self.assertEqual(session.current_state, initial_state)
 
 
 class TestCoderFleetDispatcherRedTeamActions(unittest.TestCase):

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -330,6 +330,9 @@ class TestPublicActionHandlers(unittest.TestCase):
         ACTIVE_SESSIONS["test_no_mutate_01"] = session
         initial_reports_len = len(session.breakage_reports)
         initial_state = session.current_state
+        initial_iteration_count = session.iteration_count
+        initial_active_breakages = list(session.active_breakages)
+        initial_remediation_history = list(session.remediation_history)
 
         resp = _handle_red_team_code_review({
             "action": "red_team_code_review",
@@ -339,6 +342,9 @@ class TestPublicActionHandlers(unittest.TestCase):
         self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
         self.assertEqual(len(session.breakage_reports), initial_reports_len)
         self.assertEqual(session.current_state, initial_state)
+        self.assertEqual(session.iteration_count, initial_iteration_count)
+        self.assertEqual(session.active_breakages, initial_active_breakages)
+        self.assertEqual(session.remediation_history, initial_remediation_history)
 
     def test_handle_verify_red_team_remediation_rejects_source_string_without_mutation(self) -> None:
         from fable_engine.actions.fleet import _handle_verify_red_team_remediation
@@ -347,6 +353,9 @@ class TestPublicActionHandlers(unittest.TestCase):
         ACTIVE_SESSIONS["test_no_mutate_02"] = session
         initial_reports_len = len(session.breakage_reports)
         initial_state = session.current_state
+        initial_iteration_count = session.iteration_count
+        initial_active_breakages = list(session.active_breakages)
+        initial_remediation_history = list(session.remediation_history)
 
         resp = _handle_verify_red_team_remediation({
             "action": "verify_red_team_remediation",
@@ -356,6 +365,24 @@ class TestPublicActionHandlers(unittest.TestCase):
         self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
         self.assertEqual(len(session.breakage_reports), initial_reports_len)
         self.assertEqual(session.current_state, initial_state)
+        self.assertEqual(session.iteration_count, initial_iteration_count)
+        self.assertEqual(session.active_breakages, initial_active_breakages)
+        self.assertEqual(session.remediation_history, initial_remediation_history)
+
+    def test_missing_session_name_does_not_create_session_or_file(self) -> None:
+        from fable_engine.actions.fleet import _handle_red_team_code_review, _handle_verify_red_team_remediation
+        from fable_engine.session import ACTIVE_SESSIONS, SESSIONS_DIR
+
+        initial_active_keys = set(ACTIVE_SESSIONS.keys())
+
+        resp1 = _handle_red_team_code_review({"action": "red_team_code_review"})
+        self.assertIn("Error: 'session_name' is required", resp1)
+
+        resp2 = _handle_verify_red_team_remediation({"action": "verify_red_team_remediation"})
+        self.assertIn("Error: 'session_name' is required", resp2)
+
+        self.assertEqual(set(ACTIVE_SESSIONS.keys()), initial_active_keys)
+        self.assertFalse((SESSIONS_DIR / ".json").exists())
 
 
 class TestCoderFleetDispatcherRedTeamActions(unittest.TestCase):

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -328,11 +328,7 @@ class TestPublicActionHandlers(unittest.TestCase):
         from fable_engine.session import FableSession, ACTIVE_SESSIONS
         session = FableSession(session_name="test_no_mutate_01", objective="Test no mutation", time_budget_minutes=5.0)
         ACTIVE_SESSIONS["test_no_mutate_01"] = session
-        initial_reports_len = len(session.breakage_reports)
-        initial_state = session.current_state
-        initial_iteration_count = session.iteration_count
-        initial_active_breakages = list(session.active_breakages)
-        initial_remediation_history = list(session.remediation_history)
+        snapshot = session.to_dict()
 
         resp = _handle_red_team_code_review({
             "action": "red_team_code_review",
@@ -340,22 +336,14 @@ class TestPublicActionHandlers(unittest.TestCase):
             "target_code": "def process(): pass",
         })
         self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
-        self.assertEqual(len(session.breakage_reports), initial_reports_len)
-        self.assertEqual(session.current_state, initial_state)
-        self.assertEqual(session.iteration_count, initial_iteration_count)
-        self.assertEqual(session.active_breakages, initial_active_breakages)
-        self.assertEqual(session.remediation_history, initial_remediation_history)
+        self.assertEqual(session.to_dict(), snapshot)
 
     def test_handle_verify_red_team_remediation_rejects_source_string_without_mutation(self) -> None:
         from fable_engine.actions.fleet import _handle_verify_red_team_remediation
         from fable_engine.session import FableSession, ACTIVE_SESSIONS
         session = FableSession(session_name="test_no_mutate_02", objective="Test no mutation", time_budget_minutes=5.0)
         ACTIVE_SESSIONS["test_no_mutate_02"] = session
-        initial_reports_len = len(session.breakage_reports)
-        initial_state = session.current_state
-        initial_iteration_count = session.iteration_count
-        initial_active_breakages = list(session.active_breakages)
-        initial_remediation_history = list(session.remediation_history)
+        snapshot = session.to_dict()
 
         resp = _handle_verify_red_team_remediation({
             "action": "verify_red_team_remediation",
@@ -363,11 +351,32 @@ class TestPublicActionHandlers(unittest.TestCase):
             "remediated_code": "def process(): pass",
         })
         self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
-        self.assertEqual(len(session.breakage_reports), initial_reports_len)
-        self.assertEqual(session.current_state, initial_state)
-        self.assertEqual(session.iteration_count, initial_iteration_count)
-        self.assertEqual(session.active_breakages, initial_active_breakages)
-        self.assertEqual(session.remediation_history, initial_remediation_history)
+        self.assertEqual(session.to_dict(), snapshot)
+
+    def test_rejected_source_string_with_nonexistent_session_name(self) -> None:
+        from fable_engine.actions.fleet import _handle_red_team_code_review, _handle_verify_red_team_remediation
+        from fable_engine.session import ACTIVE_SESSIONS, SESSIONS_DIR
+
+        nonexistent_name = "nonexistent_session_999"
+        self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
+
+        resp1 = _handle_red_team_code_review({
+            "action": "red_team_code_review",
+            "session_name": nonexistent_name,
+            "target_code": "def process(): pass",
+        })
+        self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp1)
+        self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
+        self.assertFalse((SESSIONS_DIR / f"{nonexistent_name}.json").exists())
+
+        resp2 = _handle_verify_red_team_remediation({
+            "action": "verify_red_team_remediation",
+            "session_name": nonexistent_name,
+            "remediated_code": "def process(): pass",
+        })
+        self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp2)
+        self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
+        self.assertFalse((SESSIONS_DIR / f"{nonexistent_name}.json").exists())
 
     def test_missing_session_name_does_not_create_session_or_file(self) -> None:
         from fable_engine.actions.fleet import _handle_red_team_code_review, _handle_verify_red_team_remediation
@@ -383,6 +392,34 @@ class TestPublicActionHandlers(unittest.TestCase):
 
         self.assertEqual(set(ACTIVE_SESSIONS.keys()), initial_active_keys)
         self.assertFalse((SESSIONS_DIR / ".json").exists())
+
+    def test_falsey_callable_object_accepted_in_public_action_handlers(self) -> None:
+        from fable_engine.actions.fleet import _handle_red_team_code_review, _handle_verify_red_team_remediation
+        from fable_engine.session import FableSession, ACTIVE_SESSIONS, SessionState
+
+        class FalseCallable:
+            def __bool__(self) -> bool:
+                return False
+
+            def __call__(self, x: Any = None) -> str:
+                return "ok"
+
+        session = FableSession(session_name="test_falsey_callable_01", objective="Test falsey callable", time_budget_minutes=5.0)
+        session.set_timer(5.0)
+        session.execution_locked = False
+        session.can_execute_code = True
+        session.transition_to(SessionState.IMPLEMENTATION, "Implemented")
+        session.track_file_change("sample.py", "created", "Added initial implementation")
+        session.transition_to(SessionState.RED_TEAM_GATE, "Ready for gate")
+        ACTIVE_SESSIONS["test_falsey_callable_01"] = session
+
+        resp = _handle_red_team_code_review({
+            "action": "red_team_code_review",
+            "session_name": "test_falsey_callable_01",
+            "target_code": FalseCallable(),
+        })
+        self.assertNotIn("Error: Source-code strings cannot be evaluated in-process", resp)
+        self.assertIn("Adversarial Red Team Resilient Attestation", resp)
 
 
 class TestCoderFleetDispatcherRedTeamActions(unittest.TestCase):

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -327,33 +327,47 @@ class TestPingPongRemediationCycle(unittest.TestCase):
 class TestPublicActionHandlers(unittest.TestCase):
     def test_handle_red_team_code_review_rejects_source_string_without_mutation(self) -> None:
         from fable_engine.actions.fleet import _handle_red_team_code_review
-        from fable_engine.session import FableSession, ACTIVE_SESSIONS
-        session = FableSession(session_name="test_no_mutate_01", objective="Test no mutation", time_budget_minutes=5.0)
-        ACTIVE_SESSIONS["test_no_mutate_01"] = session
+        from fable_engine.session import FableSession, ACTIVE_SESSIONS, SESSIONS_DIR
+        session_name = f"test_no_mutate_{uuid.uuid4().hex[:8]}"
+        session_file = SESSIONS_DIR / f"{session_name}.json"
+        session = FableSession(session_name=session_name, objective="Test no mutation", time_budget_minutes=5.0)
+        ACTIVE_SESSIONS[session_name] = session
         snapshot = copy.deepcopy(session.to_dict())
 
-        resp = _handle_red_team_code_review({
-            "action": "red_team_code_review",
-            "session_name": "test_no_mutate_01",
-            "target_code": "def process(): pass",
-        })
-        self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
-        self.assertEqual(session.to_dict(), snapshot)
+        try:
+            resp = _handle_red_team_code_review({
+                "action": "red_team_code_review",
+                "session_name": session_name,
+                "target_code": "def process(): pass",
+            })
+            self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
+            self.assertEqual(session.to_dict(), snapshot)
+        finally:
+            ACTIVE_SESSIONS.pop(session_name, None)
+            if session_file.exists():
+                session_file.unlink()
 
     def test_handle_verify_red_team_remediation_rejects_source_string_without_mutation(self) -> None:
         from fable_engine.actions.fleet import _handle_verify_red_team_remediation
-        from fable_engine.session import FableSession, ACTIVE_SESSIONS
-        session = FableSession(session_name="test_no_mutate_02", objective="Test no mutation", time_budget_minutes=5.0)
-        ACTIVE_SESSIONS["test_no_mutate_02"] = session
+        from fable_engine.session import FableSession, ACTIVE_SESSIONS, SESSIONS_DIR
+        session_name = f"test_no_mutate_{uuid.uuid4().hex[:8]}"
+        session_file = SESSIONS_DIR / f"{session_name}.json"
+        session = FableSession(session_name=session_name, objective="Test no mutation", time_budget_minutes=5.0)
+        ACTIVE_SESSIONS[session_name] = session
         snapshot = copy.deepcopy(session.to_dict())
 
-        resp = _handle_verify_red_team_remediation({
-            "action": "verify_red_team_remediation",
-            "session_name": "test_no_mutate_02",
-            "remediated_code": "def process(): pass",
-        })
-        self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
-        self.assertEqual(session.to_dict(), snapshot)
+        try:
+            resp = _handle_verify_red_team_remediation({
+                "action": "verify_red_team_remediation",
+                "session_name": session_name,
+                "remediated_code": "def process(): pass",
+            })
+            self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
+            self.assertEqual(session.to_dict(), snapshot)
+        finally:
+            ACTIVE_SESSIONS.pop(session_name, None)
+            if session_file.exists():
+                session_file.unlink()
 
     def test_rejected_source_string_with_nonexistent_session_name(self) -> None:
         from fable_engine.actions.fleet import _handle_red_team_code_review, _handle_verify_red_team_remediation
@@ -407,8 +421,8 @@ class TestPublicActionHandlers(unittest.TestCase):
         self.assertFalse((SESSIONS_DIR / ".json").exists())
 
     def test_falsey_callable_object_accepted_in_public_action_handlers(self) -> None:
-        from fable_engine.actions.fleet import _handle_red_team_code_review, _handle_verify_red_team_remediation
-        from fable_engine.session import FableSession, ACTIVE_SESSIONS, SessionState
+        from fable_engine.actions.fleet import _handle_red_team_code_review
+        from fable_engine.session import FableSession, ACTIVE_SESSIONS, SESSIONS_DIR, SessionState
 
         class FalseCallable:
             def __bool__(self) -> bool:
@@ -417,26 +431,34 @@ class TestPublicActionHandlers(unittest.TestCase):
             def __call__(self, x: Any = None) -> str:
                 return "ok"
 
-        session = FableSession(session_name="test_falsey_callable_01", objective="Test falsey callable", time_budget_minutes=5.0)
+        session_name = f"test_falsey_callable_{uuid.uuid4().hex[:8]}"
+        session_file = SESSIONS_DIR / f"{session_name}.json"
+
+        session = FableSession(session_name=session_name, objective="Test falsey callable", time_budget_minutes=5.0)
         session.set_timer(5.0)
         session.execution_locked = False
         session.can_execute_code = True
         session.transition_to(SessionState.IMPLEMENTATION, "Implemented")
         session.track_file_change("sample.py", "created", "Added initial implementation")
         session.transition_to(SessionState.RED_TEAM_GATE, "Ready for gate")
-        ACTIVE_SESSIONS["test_falsey_callable_01"] = session
+        ACTIVE_SESSIONS[session_name] = session
 
-        resp = _handle_red_team_code_review({
-            "action": "red_team_code_review",
-            "session_name": "test_falsey_callable_01",
-            "target_code": FalseCallable(),
-        })
-        self.assertNotIn("Error: Source-code strings cannot be evaluated in-process", resp)
-        self.assertIn("Adversarial Red Team Resilient Attestation", resp)
+        try:
+            resp = _handle_red_team_code_review({
+                "action": "red_team_code_review",
+                "session_name": session_name,
+                "target_code": FalseCallable(),
+            })
+            self.assertNotIn("Error: Source-code strings cannot be evaluated in-process", resp)
+            self.assertIn("Adversarial Red Team Resilient Attestation", resp)
+        finally:
+            ACTIVE_SESSIONS.pop(session_name, None)
+            if session_file.exists():
+                session_file.unlink()
 
     def test_falsey_callable_object_accepted_in_verify_red_team_remediation(self) -> None:
         from fable_engine.actions.fleet import _handle_verify_red_team_remediation
-        from fable_engine.session import FableSession, ACTIVE_SESSIONS, SessionState
+        from fable_engine.session import FableSession, ACTIVE_SESSIONS, SESSIONS_DIR, SessionState
 
         class FalseCallable:
             def __bool__(self) -> bool:
@@ -445,14 +467,17 @@ class TestPublicActionHandlers(unittest.TestCase):
             def __call__(self, x: Any = None) -> str:
                 return "ok"
 
-        session = FableSession(session_name="test_falsey_remediation_01", objective="Test falsey remediation", time_budget_minutes=5.0)
+        session_name = f"test_falsey_remediation_{uuid.uuid4().hex[:8]}"
+        session_file = SESSIONS_DIR / f"{session_name}.json"
+
+        session = FableSession(session_name=session_name, objective="Test falsey remediation", time_budget_minutes=5.0)
         session.set_timer(5.0)
         session.execution_locked = False
         session.can_execute_code = True
         session.transition_to(SessionState.IMPLEMENTATION, "Implemented")
         session.track_file_change("sample.py", "created", "Added initial implementation")
         session.transition_to(SessionState.RED_TEAM_GATE, "Ready for gate")
-        ACTIVE_SESSIONS["test_falsey_remediation_01"] = session
+        ACTIVE_SESSIONS[session_name] = session
 
         prior_report = {
             "report_id": "rep_prior_falsey",
@@ -468,14 +493,19 @@ class TestPublicActionHandlers(unittest.TestCase):
             ],
         }
 
-        resp = _handle_verify_red_team_remediation({
-            "action": "verify_red_team_remediation",
-            "session_name": "test_falsey_remediation_01",
-            "remediated_code": FalseCallable(),
-            "prior_report": prior_report,
-        })
-        self.assertNotIn("Error: Source-code strings cannot be evaluated in-process", resp)
-        self.assertIn("TASK COMPLETED: 0 breakages remain. Code sealed.", resp)
+        try:
+            resp = _handle_verify_red_team_remediation({
+                "action": "verify_red_team_remediation",
+                "session_name": session_name,
+                "remediated_code": FalseCallable(),
+                "prior_report": prior_report,
+            })
+            self.assertNotIn("Error: Source-code strings cannot be evaluated in-process", resp)
+            self.assertIn("TASK COMPLETED: 0 breakages remain. Code sealed.", resp)
+        finally:
+            ACTIVE_SESSIONS.pop(session_name, None)
+            if session_file.exists():
+                session_file.unlink()
 
 
 class TestCoderFleetDispatcherRedTeamActions(unittest.TestCase):

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -109,6 +109,46 @@ class TestRedTeamSwarmExecution(unittest.TestCase):
         self.assertEqual(len([f for f in report.findings if f.broken]), 0)
 
 
+class TestRedTeamSwarmSecurityBoundary(unittest.TestCase):
+    def setUp(self) -> None:
+        self.swarm = RedTeamSwarm()
+
+    def test_none_or_unexecutable_target_fails_closed(self) -> None:
+        report = self.swarm.execute_swarm_attack(None)
+        self.assertFalse(report.passed)
+        self.assertEqual(report.broken_count, 1)
+        self.assertEqual(report.findings[0].scenario_id, "target_not_executable")
+        self.assertIn("TypeError", report.findings[0].error_message or "")
+
+    def test_source_string_with_flaw_fails_closed(self) -> None:
+        code_snippet = (
+            "def fragile_fn(x=None):\n"
+            "    if x is None:\n"
+            "        raise AttributeError('NoneType object has no attribute')\n"
+            "    return 'ok'\n"
+        )
+        report = self.swarm.execute_swarm_attack(code_snippet)
+        self.assertFalse(report.passed)
+        self.assertGreater(report.broken_count, 0)
+
+    def test_source_string_safe_passes(self) -> None:
+        code_snippet = (
+            "def safe_fn(x=None):\n"
+            "    if x is None:\n"
+            "        return 'ok'\n"
+            "    return 'ok'\n"
+        )
+        report = self.swarm.execute_swarm_attack(code_snippet)
+        self.assertTrue(report.passed)
+        self.assertEqual(report.broken_count, 0)
+
+    def test_source_string_syntax_error_fails_closed(self) -> None:
+        code_snippet = "def bad_syntax(%%%"
+        report = self.swarm.execute_swarm_attack(code_snippet)
+        self.assertFalse(report.passed)
+        self.assertGreater(report.broken_count, 0)
+
+
 class TestReportFormattingAndSerialization(unittest.TestCase):
     def setUp(self) -> None:
         self.swarm = RedTeamSwarm()

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -10,11 +10,13 @@ Tests:
 """
 from __future__ import annotations
 
+import copy
 import os
 import sys
 import tempfile
 import threading
 import unittest
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -328,7 +330,7 @@ class TestPublicActionHandlers(unittest.TestCase):
         from fable_engine.session import FableSession, ACTIVE_SESSIONS
         session = FableSession(session_name="test_no_mutate_01", objective="Test no mutation", time_budget_minutes=5.0)
         ACTIVE_SESSIONS["test_no_mutate_01"] = session
-        snapshot = session.to_dict()
+        snapshot = copy.deepcopy(session.to_dict())
 
         resp = _handle_red_team_code_review({
             "action": "red_team_code_review",
@@ -343,7 +345,7 @@ class TestPublicActionHandlers(unittest.TestCase):
         from fable_engine.session import FableSession, ACTIVE_SESSIONS
         session = FableSession(session_name="test_no_mutate_02", objective="Test no mutation", time_budget_minutes=5.0)
         ACTIVE_SESSIONS["test_no_mutate_02"] = session
-        snapshot = session.to_dict()
+        snapshot = copy.deepcopy(session.to_dict())
 
         resp = _handle_verify_red_team_remediation({
             "action": "verify_red_team_remediation",
@@ -357,26 +359,37 @@ class TestPublicActionHandlers(unittest.TestCase):
         from fable_engine.actions.fleet import _handle_red_team_code_review, _handle_verify_red_team_remediation
         from fable_engine.session import ACTIVE_SESSIONS, SESSIONS_DIR
 
-        nonexistent_name = "nonexistent_session_999"
-        self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
+        nonexistent_name = f"nonexistent_session_{uuid.uuid4().hex[:8]}"
+        session_file = SESSIONS_DIR / f"{nonexistent_name}.json"
 
-        resp1 = _handle_red_team_code_review({
-            "action": "red_team_code_review",
-            "session_name": nonexistent_name,
-            "target_code": "def process(): pass",
-        })
-        self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp1)
-        self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
-        self.assertFalse((SESSIONS_DIR / f"{nonexistent_name}.json").exists())
+        ACTIVE_SESSIONS.pop(nonexistent_name, None)
+        if session_file.exists():
+            session_file.unlink()
 
-        resp2 = _handle_verify_red_team_remediation({
-            "action": "verify_red_team_remediation",
-            "session_name": nonexistent_name,
-            "remediated_code": "def process(): pass",
-        })
-        self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp2)
-        self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
-        self.assertFalse((SESSIONS_DIR / f"{nonexistent_name}.json").exists())
+        try:
+            self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
+
+            resp1 = _handle_red_team_code_review({
+                "action": "red_team_code_review",
+                "session_name": nonexistent_name,
+                "target_code": "def process(): pass",
+            })
+            self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp1)
+            self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
+            self.assertFalse(session_file.exists())
+
+            resp2 = _handle_verify_red_team_remediation({
+                "action": "verify_red_team_remediation",
+                "session_name": nonexistent_name,
+                "remediated_code": "def process(): pass",
+            })
+            self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp2)
+            self.assertNotIn(nonexistent_name, ACTIVE_SESSIONS)
+            self.assertFalse(session_file.exists())
+        finally:
+            ACTIVE_SESSIONS.pop(nonexistent_name, None)
+            if session_file.exists():
+                session_file.unlink()
 
     def test_missing_session_name_does_not_create_session_or_file(self) -> None:
         from fable_engine.actions.fleet import _handle_red_team_code_review, _handle_verify_red_team_remediation
@@ -420,6 +433,49 @@ class TestPublicActionHandlers(unittest.TestCase):
         })
         self.assertNotIn("Error: Source-code strings cannot be evaluated in-process", resp)
         self.assertIn("Adversarial Red Team Resilient Attestation", resp)
+
+    def test_falsey_callable_object_accepted_in_verify_red_team_remediation(self) -> None:
+        from fable_engine.actions.fleet import _handle_verify_red_team_remediation
+        from fable_engine.session import FableSession, ACTIVE_SESSIONS, SessionState
+
+        class FalseCallable:
+            def __bool__(self) -> bool:
+                return False
+
+            def __call__(self, x: Any = None) -> str:
+                return "ok"
+
+        session = FableSession(session_name="test_falsey_remediation_01", objective="Test falsey remediation", time_budget_minutes=5.0)
+        session.set_timer(5.0)
+        session.execution_locked = False
+        session.can_execute_code = True
+        session.transition_to(SessionState.IMPLEMENTATION, "Implemented")
+        session.track_file_change("sample.py", "created", "Added initial implementation")
+        session.transition_to(SessionState.RED_TEAM_GATE, "Ready for gate")
+        ACTIVE_SESSIONS["test_falsey_remediation_01"] = session
+
+        prior_report = {
+            "report_id": "rep_prior_falsey",
+            "target_name": "target",
+            "broken_count": 1,
+            "findings": [
+                {
+                    "scenario_id": "target_chaos_01_missing_path",
+                    "vector": "chaos_environment",
+                    "hypothesis": "Hypothesis",
+                    "broken": True,
+                }
+            ],
+        }
+
+        resp = _handle_verify_red_team_remediation({
+            "action": "verify_red_team_remediation",
+            "session_name": "test_falsey_remediation_01",
+            "remediated_code": FalseCallable(),
+            "prior_report": prior_report,
+        })
+        self.assertNotIn("Error: Source-code strings cannot be evaluated in-process", resp)
+        self.assertIn("TASK COMPLETED: 0 breakages remain. Code sealed.", resp)
 
 
 class TestCoderFleetDispatcherRedTeamActions(unittest.TestCase):

--- a/tests/test_red_team_swarm.py
+++ b/tests/test_red_team_swarm.py
@@ -322,6 +322,26 @@ class TestPingPongRemediationCycle(unittest.TestCase):
         self.assertGreater(len(lobe_reloaded.specialized_heuristics), 0)
 
 
+class TestPublicActionHandlers(unittest.TestCase):
+    def test_handle_red_team_code_review_rejects_source_string(self) -> None:
+        from fable_engine.actions.fleet import _handle_red_team_code_review
+        resp = _handle_red_team_code_review({
+            "action": "red_team_code_review",
+            "session_name": "test_handler_session",
+            "target_code": "def process(): pass",
+        })
+        self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
+
+    def test_handle_verify_red_team_remediation_rejects_source_string(self) -> None:
+        from fable_engine.actions.fleet import _handle_verify_red_team_remediation
+        resp = _handle_verify_red_team_remediation({
+            "action": "verify_red_team_remediation",
+            "session_name": "test_handler_session",
+            "remediated_code": "def process(): pass",
+        })
+        self.assertIn("Error: Source-code strings cannot be evaluated in-process for security reasons", resp)
+
+
 class TestCoderFleetDispatcherRedTeamActions(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
Removes `_compile_code_to_callable` and all model-controlled in-process `exec()` execution from `RedTeamSwarm` (`fable_v2/coder_fleet/red_team_swarm.py`). String inputs now safely resolve to `None` while Python callables continue to resolve normally.

---
*PR created automatically by Jules for task [12593801819999167109](https://jules.google.com/task/12593801819999167109) started by @REX-codebase*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Red-team reviews and remediation verification now accept executable callable targets only.
  * Source-code strings and other non-executable targets are rejected safely before execution, with clear failure reports.

* **Documentation**
  * Tool guidance now clarifies that executing source-code strings requires a separate sandboxed executor.

* **Bug Fixes**
  * Falsey but valid callable targets are now handled correctly.
  * Red-team attack flows consistently report missing or invalid targets instead of silently proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->